### PR TITLE
Extend Tag for non-core decoders (Fixes #14)

### DIFF
--- a/global_test.go
+++ b/global_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestParseHandlingBadBuild(t *testing.T) {
 	var cli struct {
-		Enabled bool `kong:"unknown"`
+		Enabled bool `kong:"fail='"`
 	}
 
 	args := os.Args
@@ -21,7 +21,7 @@ func TestParseHandlingBadBuild(t *testing.T) {
 
 	defer func() {
 		if r := recover(); r != nil {
-			require.Equal(t, Error{msg: "unknown is an unknown kong key"}, r)
+			require.Equal(t, Error{msg: "fail=' is not quoted properly"}, r)
 		}
 	}()
 

--- a/kong_test.go
+++ b/kong_test.go
@@ -276,14 +276,6 @@ func TestCommaInQuotes(t *testing.T) {
 	require.Equal(t, "1,2", cli.Numbers)
 }
 
-func TestUnknownKey(t *testing.T) {
-	var cli struct {
-		Numbers string `kong:"gak='hi'"`
-	}
-	_, err := New(&cli)
-	require.Error(t, err)
-}
-
 func TestBadString(t *testing.T) {
 	var cli struct {
 		Numbers string `kong:"default='yay'n"`


### PR DESCRIPTION
It now doesn't fail with an incorrect key which I don't think is ideal.