### PR TITLE
Separate validation

### DIFF
--- a/_examples/shell/main.go
+++ b/_examples/shell/main.go
@@ -9,8 +9,10 @@ import (
 )
 
 var CLI struct {
-	Help bool `kong:"help='Display help.'"`
-	Rm   struct {
+	Debug  bool   `kong:"help='Debug mode.'"`
+	Output string `kong:"help='File to output to.',placeholder='FILE'"`
+
+	Rm struct {
 		Force     bool `kong:"help='Force removal.'"`
 		Recursive bool `kong:"help='Recursively remove files.'"`
 
@@ -23,7 +25,7 @@ var CLI struct {
 }
 
 func main() {
-	app := kong.Must(&CLI).Hook(&CLI.Help, kong.Help(nil, nil))
+	app := kong.Must(&CLI, kong.Description("A shell-like example app."))
 	cmd, err := app.Parse(os.Args[1:])
 	app.FatalIfErrorf(err)
 	s, _ := json.Marshal(&CLI)

--- a/guesswidth.go
+++ b/guesswidth.go
@@ -1,0 +1,9 @@
+// +build appengine !linux,!freebsd,!darwin,!dragonfly,!netbsd,!openbsd
+
+package kong
+
+import "io"
+
+func guessWidth(w io.Writer) int {
+	return 80
+}

--- a/guesswidth_unix.go
+++ b/guesswidth_unix.go
@@ -1,0 +1,38 @@
+// +build !appengine,linux freebsd darwin dragonfly netbsd openbsd
+
+package kong
+
+import (
+	"io"
+	"os"
+	"strconv"
+	"syscall"
+	"unsafe"
+)
+
+func guessWidth(w io.Writer) int {
+	// check if COLUMNS env is set to comply with
+	// http://pubs.opengroup.org/onlinepubs/009604499/basedefs/xbd_chap08.html
+	colsStr := os.Getenv("COLUMNS")
+	if colsStr != "" {
+		if cols, err := strconv.Atoi(colsStr); err == nil {
+			return cols
+		}
+	}
+
+	if t, ok := w.(*os.File); ok {
+		fd := t.Fd()
+		var dimensions [4]uint16
+
+		if _, _, err := syscall.Syscall6(
+			syscall.SYS_IOCTL,
+			uintptr(fd),
+			uintptr(syscall.TIOCGWINSZ),
+			uintptr(unsafe.Pointer(&dimensions)),
+			0, 0, 0,
+		); err == 0 {
+			return int(dimensions[1])
+		}
+	}
+	return 80
+}

--- a/help.go
+++ b/help.go
@@ -1,36 +1,159 @@
 package kong
 
 import (
-	"text/template"
+	"bytes"
+	"fmt"
+	"go/doc"
+	"io"
+	"reflect"
+	"strings"
+
+	"github.com/aymerick/raymond"
 )
 
-const defaultHelp = `{{- with .Application -}}
-usage: {{.Name}}
+const (
+	defaultIndent   = 2
+	defaultTemplate = `
+{{#with App}}
+usage: {{Name}}
 
-{{.Help}}
-{{range .Context.Flags}}
---{{.Name}}
-{{end}}
+{{#wrap}}
+{{Help}}
+{{/wrap}}
 
-{{- end -}}
+Flags:
+{{#indent}}
+{{formatFlags Flags}}
+{{/indent}}
+
+{{#if Children}}
+{{#indent}}
+{{#each Children}}
+{{Name}}
+{{/each}}
+{{/indent}}
+{{/if}}
+{{/with}}
 `
+)
 
-var defaultHelpTemplate = template.Must(template.New("help").Parse(defaultHelp))
+var defaultHelpTemplate = raymond.MustParse(strings.TrimSpace(defaultTemplate))
+
+func init() {
+	defaultHelpTemplate.RegisterHelpers(map[string]interface{}{
+		"indent": func(options *raymond.Options) string {
+			indent, ok := options.HashProp("depth").(int)
+			if !ok {
+				indent = 2
+			}
+			width := options.Data("width").(int)
+			frame := options.NewDataFrame()
+			frame.Set("width", width-indent)
+			indentStr := strings.Repeat(" ", indent)
+			lines := strings.Split(options.FnData(frame), "\n")
+			for i, line := range lines {
+				lines[i] = indentStr + line
+			}
+			return strings.Join(lines, "\n")
+		},
+		"formatFlags": func(flags []*Flag, options *raymond.Options) string {
+			rows := [][2]string{}
+			haveShort := false
+			for _, flag := range flags {
+				if flag.Short != 0 {
+					haveShort = true
+					break
+				}
+			}
+			for _, flag := range flags {
+				if !flag.Hidden {
+					rows = append(rows, [2]string{formatFlag(haveShort, flag), flag.Help})
+				}
+			}
+			w := bytes.NewBuffer(nil)
+			formatTwoColumns(w, 0, 2, options.Data("width").(int), rows)
+			return w.String()
+		},
+		"wrap": func(options *raymond.Options) string {
+			w := bytes.NewBuffer(nil)
+			doc.ToText(w, options.Fn(), "", "  ", options.Data("width").(int))
+			return w.String()
+		},
+	})
+}
 
 // Help returns a Hook that will display help and exit.
-func Help(tmpl *template.Template, tmplctx map[string]interface{}) HookFunction {
-	return func(app *Kong, ctx *Context, trace *Trace) error {
+//
+// tmpl receives a context with several top-level values, in addition to those passed through tmplctx:
+// .Context which is of type *Context and .Path which is of type *Path.
+func Help(tmpl *raymond.Template, tmplctx map[string]interface{}) HookFunction {
+	return func(ctx *Context, path *Path) error {
 		merged := map[string]interface{}{
-			"Application": app.Model,
+			"App":     ctx.App,
+			"Context": ctx,
+			"Path":    path,
 		}
 		for k, v := range tmplctx {
 			merged[k] = v
 		}
-		err := tmpl.Execute(app.Stdout, merged)
+		frame := raymond.NewDataFrame()
+		frame.Set("width", guessWidth(ctx.App.Stdout))
+		output, err := tmpl.ExecWith(merged, frame)
 		if err != nil {
 			return err
 		}
-		app.Exit(0)
+		io.WriteString(ctx.App.Stdout, output)
+		ctx.App.Exit(0)
 		return nil
 	}
+}
+
+func formatTwoColumns(w io.Writer, indent, padding, width int, rows [][2]string) {
+	// Find size of first column.
+	s := 0
+	for _, row := range rows {
+		if c := len(row[0]); c > s && c < 30 {
+			s = c
+		}
+	}
+
+	indentStr := strings.Repeat(" ", indent)
+	offsetStr := strings.Repeat(" ", s+padding)
+
+	for _, row := range rows {
+		buf := bytes.NewBuffer(nil)
+		doc.ToText(buf, row[1], "", strings.Repeat(" ", defaultIndent), width-s-padding-indent)
+		lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+		fmt.Fprintf(w, "%s%-*s%*s", indentStr, s, row[0], padding, "")
+		if len(row[0]) >= 30 {
+			fmt.Fprintf(w, "\n%s%s", indentStr, offsetStr)
+		}
+		fmt.Fprintf(w, "%s\n", lines[0])
+		for _, line := range lines[1:] {
+			fmt.Fprintf(w, "%s%s%s\n", indentStr, offsetStr, line)
+		}
+	}
+}
+
+// haveShort will be true if there are short flags present at all in the help. Useful for column alignment.
+func formatFlag(haveShort bool, flag *Flag) string {
+	flagString := ""
+	name := flag.Name
+	isBool := flag.IsBool()
+	if flag.Short != 0 {
+		flagString += fmt.Sprintf("-%c, --%s", flag.Short, name)
+	} else {
+		if haveShort {
+			flagString += fmt.Sprintf("    --%s", name)
+		} else {
+			flagString += fmt.Sprintf("--%s", name)
+		}
+	}
+	if !isBool {
+		flagString += fmt.Sprintf("=%s", flag.FormatPlaceHolder())
+	}
+	if flag.Value.Value.Kind() == reflect.Slice {
+		flagString += " ..."
+	}
+	return flagString
 }

--- a/help_test.go
+++ b/help_test.go
@@ -1,0 +1,31 @@
+package kong
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHelp(t *testing.T) {
+	var cli struct {
+		String string `kong:"help='A string flag.'"`
+		Bool   bool   `kong:"help='A bool flag.'"`
+
+		One struct {
+		} `kong:"cmd"`
+	}
+	w := bytes.NewBuffer(nil)
+	exited := false
+	app := mustNew(t, &cli,
+		Name("test-app"),
+		Description("A test app."),
+		Writers(w, w),
+		ExitFunction(func(int) { exited = true }),
+	)
+	_, err := app.Parse([]string{"--help"})
+	require.NoError(t, err)
+	require.True(t, exited)
+	fmt.Println(w.String())
+}

--- a/model.go
+++ b/model.go
@@ -1,27 +1,70 @@
 package kong
 
-import "reflect"
+import (
+	"reflect"
+	"strconv"
+	"strings"
+)
 
 type Application struct {
 	Node
 	HelpFlag *Flag
 }
 
-// A Branch is a command or positional argument that results in a branch in the command tree.
-type Branch struct {
-	Command  *Command
-	Argument *Argument
+// Leaves returns the leaf commands/arguments in the command-line grammar.
+func (a *Application) Leaves() (out []*Node) {
+	var walk func(n *Node)
+	walk = func(n *Node) {
+		if len(n.Children) == 0 {
+			out = append(out, n)
+		}
+		for _, child := range n.Children {
+			if child.Type == CommandNode || child.Type == ArgumentNode {
+				walk(child)
+			}
+		}
+	}
+	walk(&a.Node)
+	return
 }
+
+type Argument = Node
 
 type Command = Node
 
+type NodeType int
+
+const (
+	ApplicationNode NodeType = iota
+	CommandNode
+	ArgumentNode
+)
+
 type Node struct {
+	Type       NodeType
+	Parent     *Node
 	Name       string
 	Help       string
 	Flags      []*Flag
-	Positional []*Value
-	Children   []*Branch
-	Target     reflect.Value
+	Positional []*Positional
+	Children   []*Node
+	Target     reflect.Value // Pointer to the value in the grammar that this Node is associated with.
+
+	Argument *Value // Populated when Type is ArgumentNode.
+}
+
+// Path through ancestors to this Node.
+func (n *Node) Path() (out string) {
+	if n.Parent != nil {
+		out += " " + n.Parent.Path()
+	}
+	switch n.Type {
+	case ApplicationNode, CommandNode:
+		out += " " + n.Name
+	case ArgumentNode:
+		out += " " + "<" + n.Name + ">"
+	}
+	return strings.TrimSpace(out)
 }
 
 // A Value is either a flag or a variable positional argument.
@@ -36,6 +79,11 @@ type Value struct {
 	Required bool
 	Set      bool   // Used with Required to test if a value has been given.
 	Format   string // Formatting directive, if applicable.
+	Position int    // Position (for positional arguments).
+}
+
+func (v *Value) IsBool() bool {
+	return v.Value.Kind() == reflect.Bool
 }
 
 // Parse tokens into value, parse, and validate, but do not write to the field.
@@ -69,14 +117,28 @@ func (v *Value) Reset() error {
 
 type Positional = Value
 
-type Argument struct {
-	Node
-	Argument *Value
-}
-
 type Flag struct {
 	Value
-	Placeholder string
+	PlaceHolder string
 	Env         string
 	Short       rune
+	Hidden      bool
+}
+
+func (f *Flag) FormatPlaceHolder() string {
+	if f.PlaceHolder != "" {
+		return f.PlaceHolder
+	}
+	if f.Default != "" {
+		ellipsis := ""
+		if len(f.Default) > 1 {
+			ellipsis = "..."
+		}
+
+		if f.Value.Value.Kind() == reflect.String {
+			return strconv.Quote(f.Default) + ellipsis
+		}
+		return f.Default + ellipsis
+	}
+	return strings.ToUpper(f.Name)
 }

--- a/model_test.go
+++ b/model_test.go
@@ -1,0 +1,27 @@
+package kong
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestModelApplicationCommands(t *testing.T) {
+	var cli struct {
+		One struct {
+			Two struct {
+			} `kong:"cmd"`
+			Three struct {
+				Four struct {
+					Four string `kong:"arg"`
+				} `kong:"arg"`
+			} `kong:"cmd"`
+		} `kong:"cmd"`
+	}
+	p := mustNew(t, &cli)
+	actual := []string{}
+	for _, cmd := range p.Leaves() {
+		actual = append(actual, cmd.Path())
+	}
+	require.Equal(t, []string{"one two", "one three <four>"}, actual)
+}

--- a/options.go
+++ b/options.go
@@ -3,9 +3,12 @@ package kong
 import (
 	"io"
 	"reflect"
-	"text/template"
 )
 
+// Options apply optional changes to the Kong application.
+//
+// Note that Options are applied twice: once just prior to the grammar is constructed and once after. In the
+// former case, Kong.Application will be nil.
 type Option func(k *Kong)
 
 // ExitFunction overrides the function used to terminate. This is useful for testing or interactive use.
@@ -22,24 +25,20 @@ func NoDefaultHelp() Option {
 
 // Name overrides the application name.
 func Name(name string) Option {
-	return func(k *Kong) { k.Model.Name = name }
+	return func(k *Kong) {
+		if k.Application != nil {
+			k.Name = name
+		}
+	}
 }
 
 // Description sets the application description.
 func Description(description string) Option {
-	return func(k *Kong) { k.Model.Help = description }
-}
-
-// HelpTemplate overrides the default help template.
-func HelpTemplate(template *template.Template) Option {
-	return func(k *Kong) { k.help = template }
-}
-
-// HelpContext sets extra context in the help template.
-//
-// The key "Application" will always be available and is the root of the application model.
-func HelpContext(context map[string]interface{}) Option {
-	return func(k *Kong) { k.helpContext = context }
+	return func(k *Kong) {
+		if k.Application != nil {
+			k.Help = description
+		}
+	}
 }
 
 // Writers overrides the default writers. Useful for testing or interactive use.

--- a/options_test.go
+++ b/options_test.go
@@ -10,8 +10,8 @@ func TestOptions(t *testing.T) {
 	var cli struct{}
 	p, err := New(&cli, Name("name"), Description("description"), Writers(nil, nil), ExitFunction(nil))
 	require.NoError(t, err)
-	require.Equal(t, "name", p.Model.Name)
-	require.Equal(t, "description", p.Model.Help)
+	require.Equal(t, "name", p.Name)
+	require.Equal(t, "description", p.Help)
 	require.Nil(t, p.Stdout)
 	require.Nil(t, p.Stderr)
 	require.Nil(t, p.Exit)

--- a/tag.go
+++ b/tag.go
@@ -17,9 +17,10 @@ type Tag struct {
 	Type        string
 	Default     string
 	Format      string
-	Placeholder string
+	PlaceHolder string
 	Env         string
 	Short       rune
+	Hidden      bool
 
 	// Storage for all tag keys for arbitrary lookups.
 	items map[string]string
@@ -109,10 +110,11 @@ func parseTag(fv reflect.Value, s string) *Tag {
 	t.Type, _ = t.Get("type")
 	t.Env, _ = t.Get("env")
 	t.Short, _ = t.GetRune("short")
+	t.Hidden = t.Has("hidden")
 
-	t.Placeholder, _ = t.Get("placeholder")
-	if t.Placeholder == "" {
-		t.Placeholder = strings.ToUpper(dashedString(fv.Type().Name()))
+	t.PlaceHolder, _ = t.Get("placeholder")
+	if t.PlaceHolder == "" {
+		t.PlaceHolder = strings.ToUpper(dashedString(fv.Type().Name()))
 	}
 
 	return t


### PR DESCRIPTION
This allows help to be called even when the parse trace is invalid.
Without this, the command-line would have to be valid in order to use
help at all, which defeats the purpose.
