### PR TITLE
Initial --help returns exit code 0 change

### DIFF
--- a/help.go
+++ b/help.go
@@ -23,7 +23,7 @@ func (h helpValue) BeforeApply(ctx *Context) error {
 	if err != nil {
 		return err
 	}
-	ctx.Kong.Exit(1)
+	ctx.Kong.Exit(0)
 	return nil
 }
 


### PR DESCRIPTION
This quick change seems to fix the issue #38 by returning `0` for the exit code when calling `--help` 

Let me know if I'm overlooking some other use case with this code block that requires another approach to resolving this.  😃