### PR TITLE
Show used config files

### DIFF
--- a/kong.go
+++ b/kong.go
@@ -46,6 +46,7 @@ type Kong struct {
 	loader    ConfigurationLoader
 	resolvers []Resolver
 	registry  *Registry
+	configs   []string
 
 	noDefaultHelp bool
 	usageOnError  bool
@@ -343,6 +344,7 @@ func (k *Kong) LoadConfig(path string) (Resolver, error) {
 	if err != nil {
 		return nil, err
 	}
+	k.configs = append(k.configs, path)
 	defer r.Close()
 
 	return k.loader(r)

--- a/util.go
+++ b/util.go
@@ -33,3 +33,20 @@ func (v VersionFlag) BeforeApply(app *Kong, vars Vars) error {
 	app.Exit(0)
 	return nil
 }
+
+// DebugConfigFlag displays the parsed configuration files defined via kong.Configuration(loader).
+//
+// Use this flag to determine which files got parsed in which order.
+type DebugConfigFlag bool
+
+// BeforeApply writes the parsed configuration files to stderr.
+func (d DebugConfigFlag) BeforeApply(app *Kong, ctx *Context, path *Path) error {
+	show := bool(ctx.FlagValue(path.Flag).(DebugConfigFlag))
+	if show {
+		fmt.Fprintln(app.Stderr, "Parsed configuration files:")
+		for _, p := range app.configs {
+			fmt.Fprintln(app.Stderr, SpaceIndenter("")+p)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This solves #49 without breaking the API.

It creates a new Flag `DebugConfigFlag` which is optional to use.

I also added a test to verify above flag.