### PR TITLE
Added -h as default short parameter for the automatic --help flag.

### DIFF
--- a/kong.go
+++ b/kong.go
@@ -171,6 +171,7 @@ func (k *Kong) extraFlags() []*Flag {
 	var helpTarget helpValue
 	value := reflect.ValueOf(&helpTarget).Elem()
 	helpFlag := &Flag{
+		Short: 'h',
 		Value: &Value{
 			Name:         "help",
 			Help:         "Show context-sensitive help.",


### PR DESCRIPTION
Tested on my machine - the little tweak works for both the global --help summary and sub-command summary as well. `-h` is now the default short-hand for `--help`.