### PR TITLE
Fix help tests with the introduction of -h

### DIFF
--- a/help_test.go
+++ b/help_test.go
@@ -67,13 +67,13 @@ func TestHelp(t *testing.T) {
 A test app.
 
 Flags:
-  --help                 Show context-sensitive help.
-  --string=STRING        A string flag.
-  --bool                 A bool flag with very long help that wraps a lot and is
-                         verbose and is really verbose.
-  --slice=STR,...        A slice of strings.
-  --map=KEY=VALUE;...    A map of strings to ints.
-  --required             A required flag.
+  -h, --help                 Show context-sensitive help.
+      --string=STRING        A string flag.
+      --bool                 A bool flag with very long help that wraps a lot
+                             and is verbose and is really verbose.
+      --slice=STR,...        A slice of strings.
+      --map=KEY=VALUE;...    A map of strings to ints.
+      --required             A required flag.
 
 Commands:
   one --required
@@ -107,18 +107,18 @@ Sub-sub-arg.
 Detailed help provided through the HelpProvider interface.
 
 Flags:
-  --help                 Show context-sensitive help.
-  --string=STRING        A string flag.
-  --bool                 A bool flag with very long help that wraps a lot and is
-                         verbose and is really verbose.
-  --slice=STR,...        A slice of strings.
-  --map=KEY=VALUE;...    A map of strings to ints.
-  --required             A required flag.
+  -h, --help                 Show context-sensitive help.
+      --string=STRING        A string flag.
+      --bool                 A bool flag with very long help that wraps a lot
+                             and is verbose and is really verbose.
+      --slice=STR,...        A slice of strings.
+      --map=KEY=VALUE;...    A map of strings to ints.
+      --required             A required flag.
 
-  --flag=STRING          Nested flag under two.
-  --required-two
+      --flag=STRING          Nested flag under two.
+      --required-two
 
-  --required-three
+      --required-three
 `
 		t.Log(expected)
 		t.Log(w.String())
@@ -173,7 +173,7 @@ func TestHelpTree(t *testing.T) {
 A test app.
 
 Flags:
-  --help    Show context-sensitive help.
+  -h, --help    Show context-sensitive help.
 
 Commands:
   one          subcommand one
@@ -206,7 +206,7 @@ Run "test-app <command> --help" for more information on a command.
 subcommand one
 
 Flags:
-  --help    Show context-sensitive help.
+  -h, --help    Show context-sensitive help.
 
 Commands:
   thing      subcommand thing


### PR DESCRIPTION
Commit c77deac080b5dd847a46540a186ea923b68b276a in PR #83 added `h` as the short flag for help, but the help tests were not updated. Update the tests with the `-h` in the help output.