### PR TITLE
Add UsageOnMissing option to Kong

### DIFF
--- a/context.go
+++ b/context.go
@@ -187,6 +187,9 @@ func (c *Context) Validate() error { // nolint: gocyclo
 	}
 
 	if err := checkMissingChildren(node); err != nil {
+		if c.Kong.usageOnMissing {
+			return c.PrintUsage(false)
+		}
 		return err
 	}
 	if err := checkMissingPositionals(positionals, node.Positional); err != nil {
@@ -624,6 +627,9 @@ func (c *Context) Run(binds ...interface{}) (err error) {
 	defer catch(&err)
 	node := c.Selected()
 	if node == nil {
+		if c.Kong.usageOnMissing {
+			return nil
+		}
 		return fmt.Errorf("no command selected")
 	}
 	return c.RunNode(node, binds...)

--- a/kong.go
+++ b/kong.go
@@ -47,13 +47,14 @@ type Kong struct {
 	resolvers []Resolver
 	registry  *Registry
 
-	noDefaultHelp bool
-	usageOnError  bool
-	help          HelpPrinter
-	helpFormatter HelpValueFormatter
-	helpOptions   HelpOptions
-	helpFlag      *Flag
-	vars          Vars
+	noDefaultHelp  bool
+	usageOnError   bool
+	usageOnMissing bool
+	help           HelpPrinter
+	helpFormatter  HelpValueFormatter
+	helpOptions    HelpOptions
+	helpFlag       *Flag
+	vars           Vars
 
 	// Set temporarily by Options. These are applied after build().
 	postBuildOptions []Option

--- a/options.go
+++ b/options.go
@@ -216,6 +216,14 @@ func UsageOnError() Option {
 	})
 }
 
+// UsageOnMissing configures Kong to display usage and exit successfully if command is missing a child argument.
+func UsageOnMissing() Option {
+	return OptionFunc(func(k *Kong) error {
+		k.usageOnMissing = true
+		return nil
+	})
+}
+
 // ClearResolvers clears all existing resolvers.
 func ClearResolvers() Option {
 	return OptionFunc(func(k *Kong) error {


### PR DESCRIPTION
Adds a UsageOnMissing option which configures Kong to omit errors and
display usage when a command is invalid due to a missing argument. This
can be useful if a user wishes for the top-level command print usage
when no args are supplied, or if they would prefer child commands which
have their own subcommands to print usage specific to that command.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have provided some examples below when used with `crank` the CLI for @crossplane. Note that they all also have `UsageOnError()` supplied. This demonstrates how `UsageOnMissing()` plays nicely (i.e. no duplicate usage msg) by not returning an error.

**Top-level command without UsageOnMissing()**

```
$ crank
Usage: crank <command>

A tool for building platforms on Crossplane.

Flags:
  -h, --help    Show context-sensitive help.

Commands:
  configuration get [<name>]
    Get installed Configurations.

  configuration create <name> <package>
    Create a Configuration.

  provider get [<name>]
    Get installed Providers.

  provider create <name> <package>
    Create a Provider.

  pkg build [<name>]
    Build a Crossplane package.

  pkg push [<name>]
    Push a Crossplane package to a registry.

Run "crank <command> --help" for more information on a command.

crank: error: expected one of "configuration",  "provider",  "pkg"
exit status 1

```

**Top-level command with UsageOnMissing()**

```
$ crank
Usage: crank <command>

A tool for building platforms on Crossplane.

Flags:
  -h, --help    Show context-sensitive help.

Commands:
  configuration get [<name>]
    Get installed Configurations.

  configuration create <name> <package>
    Create a Configuration.

  provider get [<name>]
    Get installed Providers.

  provider create <name> <package>
    Create a Provider.

  pkg build [<name>]
    Build a Crossplane package.

  pkg push [<name>]
    Push a Crossplane package to a registry.

Run "crank <command> --help" for more information on a command.
```

**Example child command without UsageOnMissing()**

```
$ crank pkg
Usage: crank pkg <command>

Build and publish packages.

Flags:
  -h, --help    Show context-sensitive help.

Commands:
  pkg build [<name>]
    Build a Crossplane package.

  pkg push [<name>]
    Push a Crossplane package to a registry.

crank: error: expected one of "build",  "push"
exit status 1

```

**Example child command with UsageOnMissing()**

```
$ crank pkg
Usage: crank pkg <command>

Build and publish packages.

Flags:
  -h, --help    Show context-sensitive help.

Commands:
  pkg build [<name>]
    Build a Crossplane package.

  pkg push [<name>]
    Push a Crossplane package to a registry.
```