### PR TITLE
Do not run parent node on missing child err with usageOnMissing option

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,5 +1,10 @@
 package kong
 
+import (
+	"fmt"
+	"strings"
+)
+
 // ParseError is the error type returned by Kong.Parse().
 //
 // It contains the parse Context that triggered the error.
@@ -10,3 +15,29 @@ type ParseError struct {
 
 // Cause returns the original cause of the error.
 func (p *ParseError) Cause() error { return p.error }
+
+type missingChildError struct {
+	missing []string
+}
+
+func (m *missingChildError) Error() string {
+	if len(m.missing) > 5 {
+		m.missing = append(m.missing[:5], "...")
+	}
+	if len(m.missing) == 1 {
+		return fmt.Sprintf("expected %s", m.missing[0])
+	}
+	return fmt.Sprintf("expected one of %s", strings.Join(m.missing, ",  "))
+}
+
+func newMissingChildError(missing []string) *missingChildError {
+	return &missingChildError{missing}
+}
+
+func isMissingChildError(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := err.(*missingChildError)
+	return ok
+}

--- a/kong.go
+++ b/kong.go
@@ -219,7 +219,10 @@ func (k *Kong) Parse(args []string) (ctx *Context, err error) {
 		return nil, &ParseError{error: err, Context: ctx}
 	}
 	if err = ctx.Validate(); err != nil {
-		return nil, &ParseError{error: err, Context: ctx}
+		if !k.usageOnError || !isMissingChildError(err) {
+			return nil, &ParseError{error: err, Context: ctx}
+		}
+		ctx.Error = err
 	}
 	if err = k.applyHook(ctx, "AfterApply"); err != nil {
 		return nil, &ParseError{error: err, Context: ctx}


### PR DESCRIPTION
Refactors usageOnMissing option to not run parent commands after
printing usage when a child node is missing.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Follow up to #108 

@alecthomas I opted to not make the custom error type (and related functions) exported because I don't see it as worth adding to the public API.