### PR TITLE
Fix minor typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ type Mapper interface {
   // Decode scan into target.
   //
   // "ctx" contains context about the value being decoded that may be useful
-  // to some mapperss.
+  // to some mappers.
   Decode(ctx *MapperContext, scan *Scanner, target reflect.Value) error
 }
 ```


### PR DESCRIPTION
Corrects mapperss to mappers.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>