### PR TITLE
Fix return err for PrintUsage

### DIFF
--- a/context.go
+++ b/context.go
@@ -694,8 +694,7 @@ func (c *Context) Run(binds ...interface{}) (err error) {
 func (c *Context) PrintUsage(summary bool) error {
 	options := c.helpOptions
 	options.Summary = summary
-	_ = c.help(options, c)
-	return nil
+	return c.help(options, c)
 }
 
 func checkMissingFlags(flags []*Flag) error {


### PR DESCRIPTION
`PrintUsage()` returns now the error from the `c.help()` call
Fix #116 