### PR TITLE
Add support for groups in the default HelpPrinter

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,7 +589,7 @@ The default help output is usually sufficient, but if not there are two solution
 1. Use `ConfigureHelp(HelpOptions)` to configure how help is formatted (see [HelpOptions](https://godoc.org/github.com/alecthomas/kong#HelpOptions) for details).
 2. Custom help can be wired into Kong via the `Help(HelpFunc)` option. The `HelpFunc` is passed a `Context`, which contains the parsed context for the current command-line. See the implementation of `PrintHelp` for an example.
 3. Use `HelpFormatter(HelpValueFormatter)` if you want to just customize the help text that is accompanied by flags and arguments.
-4. Use `Groups(map[string]Group)` if you want to customize group titles or add a header.
+4. Use `Groups([]Group)` if you want to customize group titles or add a header.
 
 ### `Bind(...)` - bind values for callback hooks and Run() methods
 

--- a/README.md
+++ b/README.md
@@ -589,6 +589,7 @@ The default help output is usually sufficient, but if not there are two solution
 1. Use `ConfigureHelp(HelpOptions)` to configure how help is formatted (see [HelpOptions](https://godoc.org/github.com/alecthomas/kong#HelpOptions) for details).
 2. Custom help can be wired into Kong via the `Help(HelpFunc)` option. The `HelpFunc` is passed a `Context`, which contains the parsed context for the current command-line. See the implementation of `PrintHelp` for an example.
 3. Use `HelpFormatter(HelpValueFormatter)` if you want to just customize the help text that is accompanied by flags and arguments.
+4. Use `Groups(map[string]Group)` if you want to customize group titles or add a header.
 
 ### `Bind(...)` - bind values for callback hooks and Run() methods
 

--- a/build.go
+++ b/build.go
@@ -142,7 +142,7 @@ func buildChild(k *Kong, node *Node, typ NodeType, v reflect.Value, ft reflect.S
 	child.Parent = node
 	child.Help = tag.Help
 	child.Hidden = tag.Hidden
-	child.Group = tag.Group
+	child.Group = buildGroupForKey(k, tag.Group)
 	child.Aliases = tag.Aliases
 
 	if provider, ok := fv.Addr().Interface().(HelpProvider); ok {
@@ -213,11 +213,28 @@ func buildField(k *Kong, node *Node, v reflect.Value, ft reflect.StructField, fv
 			Short:       tag.Short,
 			PlaceHolder: tag.PlaceHolder,
 			Env:         tag.Env,
-			Group:       tag.Group,
+			Group:       buildGroupForKey(k, tag.Group),
 			Xor:         tag.Xor,
 			Hidden:      tag.Hidden,
 		}
 		value.Flag = flag
 		node.Flags = append(node.Flags, flag)
+	}
+}
+
+func buildGroupForKey(k *Kong, key string) *Group {
+	if key == "" {
+		return nil
+	}
+	for _, group := range k.groups {
+		if group.Key == key {
+			return &group
+		}
+	}
+
+	// No group provided with kong.Groups. We create one ad-hoc for this key.
+	return &Group{
+		Key:   key,
+		Title: key,
 	}
 }

--- a/help_test.go
+++ b/help_test.go
@@ -295,6 +295,16 @@ func TestHelpGrouping(t *testing.T) {
 	app := mustNew(t, &cli,
 		kong.Name("test-app"),
 		kong.Description("A test app."),
+		kong.Groups(map[string]kong.Group{
+			"Group A": {
+				Title:  "Group title taken from the kong.Groups option",
+				Header: "A group header",
+			},
+			"Group 1": {
+				Title: "Another group title, this time without header",
+			},
+			"Unknown key": {},
+		}),
 		kong.Writers(w, w),
 		kong.Exit(func(int) {
 			exited = true
@@ -324,7 +334,8 @@ Commands:
   two
     A non grouped subcommand.
 
-Group A:
+Group title taken from the kong.Groups option
+A group header
   one thing <arg>
     subcommand thing
 
@@ -334,7 +345,7 @@ Group A:
   three
     Another subcommand grouped in A.
 
-Group B:
+Group B
   one <stuff>
     subcommand stuff
 

--- a/help_test.go
+++ b/help_test.go
@@ -136,7 +136,7 @@ func TestHelpTree(t *testing.T) {
 			Other struct {
 				Other string `arg help:"other arg"`
 			} `arg help:"subcommand other"`
-		} `cmd help:"subcommand one"`
+		} `cmd help:"subcommand one" group:"Group A"` // Groups are ignored in trees
 
 		Two struct {
 			Three threeArg `arg help:"Sub-sub-arg."`
@@ -247,4 +247,135 @@ func TestCustomHelpFormatter(t *testing.T) {
 	_, err := p.Parse([]string{"--help"})
 	require.NoError(t, err)
 	require.Contains(t, w.String(), "A flag.")
+}
+
+func TestHelpGrouping(t *testing.T) {
+	// nolint: govet
+	var cli struct {
+		GroupedAString string `help:"A string flag grouped in A." group:"Group A"`
+		FreeString     string `help:"A non grouped string flag."`
+		GroupedBString string `help:"A string flag grouped in B." group:"Group B"`
+		FreeBool       bool   `help:"A non grouped bool flag."`
+		GroupedABool   bool   `help:"A bool flag grouped in A." group:"Group A"`
+
+		One struct {
+			Flag string `help:"Nested flag."`
+			// Group is inherited from the parent command
+			Thing struct {
+				Arg string `arg help:"argument"`
+			} `cmd help:"subcommand thing"`
+			Other struct {
+				Other string `arg help:"other arg"`
+			} `arg help:"subcommand other"`
+			// ... but a subcommand can override it
+			Stuff struct {
+				Stuff string `arg help:"argument"`
+			} `arg help:"subcommand stuff" group:"Group B"`
+		} `cmd help:"A subcommand grouped in A." group:"Group A"`
+
+		Two struct {
+			Grouped1String string `help:"A string flag grouped in A." group:"Group 1"`
+			AFreeString    string `help:"A non grouped string flag."`
+			Grouped2String string `help:"A string flag grouped in B." group:"Group 2"`
+			AFreeBool      bool   `help:"A non grouped bool flag."`
+			Grouped1Bool   bool   `help:"A bool flag grouped in A." group:"Group 1"`
+		} `cmd help:"A non grouped subcommand."`
+
+		Four struct {
+			Flag string `help:"Nested flag."`
+		} `cmd help:"Another subcommand grouped in B." group:"Group B"`
+
+		Three struct {
+			Flag string `help:"Nested flag."`
+		} `cmd help:"Another subcommand grouped in A." group:"Group A"`
+	}
+
+	w := bytes.NewBuffer(nil)
+	exited := false
+	app := mustNew(t, &cli,
+		kong.Name("test-app"),
+		kong.Description("A test app."),
+		kong.Writers(w, w),
+		kong.Exit(func(int) {
+			exited = true
+			panic(true) // Panic to fake "exit".
+		}),
+	)
+
+	t.Run("Full", func(t *testing.T) {
+		require.PanicsWithValue(t, true, func() {
+			_, err := app.Parse([]string{"--help"})
+			require.True(t, exited)
+			require.NoError(t, err)
+		})
+		expected := `Usage: test-app <command>
+
+A test app.
+
+Flags:
+  -h, --help                       Show context-sensitive help.
+      --grouped-a-string=STRING    A string flag grouped in A.
+      --free-string=STRING         A non grouped string flag.
+      --grouped-b-string=STRING    A string flag grouped in B.
+      --free-bool                  A non grouped bool flag.
+      --grouped-a-bool             A bool flag grouped in A.
+
+Commands:
+  two
+    A non grouped subcommand.
+
+Group A:
+  one thing <arg>
+    subcommand thing
+
+  one <other>
+    subcommand other
+
+  three
+    Another subcommand grouped in A.
+
+Group B:
+  one <stuff>
+    subcommand stuff
+
+  four
+    Another subcommand grouped in B.
+
+Run "test-app <command> --help" for more information on a command.
+`
+		t.Log(w.String())
+		t.Log(expected)
+		require.Equal(t, expected, w.String())
+	})
+
+	t.Run("Selected", func(t *testing.T) {
+		exited = false
+		w.Truncate(0)
+		require.PanicsWithValue(t, true, func() {
+			_, err := app.Parse([]string{"two", "--help"})
+			require.NoError(t, err)
+			require.True(t, exited)
+		})
+		expected := `Usage: test-app two
+
+A non grouped subcommand.
+
+Flags:
+  -h, --help                       Show context-sensitive help.
+      --grouped-a-string=STRING    A string flag grouped in A.
+      --free-string=STRING         A non grouped string flag.
+      --grouped-b-string=STRING    A string flag grouped in B.
+      --free-bool                  A non grouped bool flag.
+      --grouped-a-bool             A bool flag grouped in A.
+
+      --grouped-1-string=STRING    A string flag grouped in A.
+      --a-free-string=STRING       A non grouped string flag.
+      --grouped-2-string=STRING    A string flag grouped in B.
+      --a-free-bool                A non grouped bool flag.
+      --grouped-1-bool             A bool flag grouped in A.
+`
+		t.Log(expected)
+		t.Log(w.String())
+		require.Equal(t, expected, w.String())
+	})
 }

--- a/help_test.go
+++ b/help_test.go
@@ -295,15 +295,19 @@ func TestHelpGrouping(t *testing.T) {
 	app := mustNew(t, &cli,
 		kong.Name("test-app"),
 		kong.Description("A test app."),
-		kong.Groups(map[string]kong.Group{
-			"Group A": {
+		kong.Groups([]kong.Group{
+			{
+				Key:    "Group A",
 				Title:  "Group title taken from the kong.Groups option",
 				Header: "A group header",
 			},
-			"Group 1": {
+			{
+				Key:   "Group 1",
 				Title: "Another group title, this time without header",
 			},
-			"Unknown key": {},
+			{
+				Key: "Unknown key",
+			},
 		}),
 		kong.Writers(w, w),
 		kong.Exit(func(int) {

--- a/help_test.go
+++ b/help_test.go
@@ -274,11 +274,11 @@ func TestHelpGrouping(t *testing.T) {
 		} `cmd help:"A subcommand grouped in A." group:"Group A"`
 
 		Two struct {
-			Grouped1String string `help:"A string flag grouped in A." group:"Group 1"`
-			AFreeString    string `help:"A non grouped string flag."`
-			Grouped2String string `help:"A string flag grouped in B." group:"Group 2"`
-			AFreeBool      bool   `help:"A non grouped bool flag."`
-			Grouped1Bool   bool   `help:"A bool flag grouped in A." group:"Group 1"`
+			Grouped1String  string `help:"A string flag grouped in 1." group:"Group 1"`
+			AFreeString     string `help:"A non grouped string flag."`
+			Grouped2String  string `help:"A string flag grouped in 2." group:"Group 2"`
+			AGroupedAString bool   `help:"A string flag grouped in A." group:"Group A"`
+			Grouped1Bool    bool   `help:"A bool flag grouped in 1." group:"Group 1"`
 		} `cmd help:"A non grouped subcommand."`
 
 		Four struct {
@@ -323,12 +323,17 @@ func TestHelpGrouping(t *testing.T) {
 A test app.
 
 Flags:
-  -h, --help                       Show context-sensitive help.
-      --grouped-a-string=STRING    A string flag grouped in A.
-      --free-string=STRING         A non grouped string flag.
-      --grouped-b-string=STRING    A string flag grouped in B.
-      --free-bool                  A non grouped bool flag.
-      --grouped-a-bool             A bool flag grouped in A.
+  -h, --help                  Show context-sensitive help.
+      --free-string=STRING    A non grouped string flag.
+      --free-bool             A non grouped bool flag.
+
+Group title taken from the kong.Groups option
+A group header
+  --grouped-a-string=STRING    A string flag grouped in A.
+  --grouped-a-bool             A bool flag grouped in A.
+
+Group B
+  --grouped-b-string=STRING    A string flag grouped in B.
 
 Commands:
   two
@@ -372,18 +377,28 @@ Run "test-app <command> --help" for more information on a command.
 A non grouped subcommand.
 
 Flags:
-  -h, --help                       Show context-sensitive help.
-      --grouped-a-string=STRING    A string flag grouped in A.
-      --free-string=STRING         A non grouped string flag.
-      --grouped-b-string=STRING    A string flag grouped in B.
-      --free-bool                  A non grouped bool flag.
-      --grouped-a-bool             A bool flag grouped in A.
+  -h, --help                    Show context-sensitive help.
+      --free-string=STRING      A non grouped string flag.
+      --free-bool               A non grouped bool flag.
 
-      --grouped-1-string=STRING    A string flag grouped in A.
-      --a-free-string=STRING       A non grouped string flag.
-      --grouped-2-string=STRING    A string flag grouped in B.
-      --a-free-bool                A non grouped bool flag.
-      --grouped-1-bool             A bool flag grouped in A.
+      --a-free-string=STRING    A non grouped string flag.
+
+Group title taken from the kong.Groups option
+A group header
+  --grouped-a-string=STRING    A string flag grouped in A.
+  --grouped-a-bool             A bool flag grouped in A.
+
+  --a-grouped-a-string         A string flag grouped in A.
+
+Group B
+  --grouped-b-string=STRING    A string flag grouped in B.
+
+Another group title, this time without header
+  --grouped-1-string=STRING    A string flag grouped in 1.
+  --grouped-1-bool             A bool flag grouped in 1.
+
+Group 2
+  --grouped-2-string=STRING    A string flag grouped in 2.
 `
 		t.Log(expected)
 		t.Log(w.String())

--- a/kong.go
+++ b/kong.go
@@ -53,7 +53,7 @@ type Kong struct {
 	helpFormatter HelpValueFormatter
 	helpOptions   HelpOptions
 	helpFlag      *Flag
-	groups        map[string]Group
+	groups        []Group
 	vars          Vars
 
 	// Set temporarily by Options. These are applied after build().

--- a/kong.go
+++ b/kong.go
@@ -53,6 +53,7 @@ type Kong struct {
 	helpFormatter HelpValueFormatter
 	helpOptions   HelpOptions
 	helpFlag      *Flag
+	groups        map[string]Group
 	vars          Vars
 
 	// Set temporarily by Options. These are applied after build().

--- a/model.go
+++ b/model.go
@@ -46,7 +46,7 @@ type Node struct {
 	Name       string
 	Help       string // Short help displayed in summaries.
 	Detail     string // Detailed help displayed when describing command/arg alone.
-	Group      string
+	Group      *Group
 	Hidden     bool
 	Flags      []*Flag
 	Positional []*Positional
@@ -203,15 +203,15 @@ func (n *Node) Path() (out string) {
 	return strings.TrimSpace(out)
 }
 
-// ClosestGroup finds the first non-empty group in this node and its ancestors.
-func (n *Node) ClosestGroup() string {
+// ClosestGroup finds the first non-nil group in this node and its ancestors.
+func (n *Node) ClosestGroup() *Group {
 	switch {
-	case n.Group != "":
+	case n.Group != nil:
 		return n.Group
 	case n.Parent != nil:
 		return n.Parent.ClosestGroup()
 	default:
-		return ""
+		return nil
 	}
 }
 
@@ -363,7 +363,7 @@ type Positional = Value
 // A Flag represents a command-line flag.
 type Flag struct {
 	*Value
-	Group       string // Logical grouping when displaying. May also be used by configuration loaders to group options logically.
+	Group       *Group // Logical grouping when displaying. May also be used by configuration loaders to group options logically.
 	Xor         string
 	PlaceHolder string
 	Env         string
@@ -404,6 +404,17 @@ func (f *Flag) FormatPlaceHolder() string {
 		return "KEY=VALUE" + tail
 	}
 	return strings.ToUpper(f.Name) + tail
+}
+
+// Group holds metadata about a command or flag group used when printing help.
+type Group struct {
+	// Key is the `group` field tag value used to identify this group.
+	Key string
+	// Title is displayed above the grouped items.
+	Title string
+	// Header is optional and displayed under the Title when non empty.
+	// It can be used to introduce the group's purpose to the user.
+	Header string
 }
 
 // This is directly from the Go 1.13 source code.

--- a/model.go
+++ b/model.go
@@ -203,6 +203,18 @@ func (n *Node) Path() (out string) {
 	return strings.TrimSpace(out)
 }
 
+// ClosestGroup finds the first non-empty group in this node and its ancestors.
+func (n *Node) ClosestGroup() string {
+	switch {
+	case n.Group != "":
+		return n.Group
+	case n.Parent != nil:
+		return n.Parent.ClosestGroup()
+	default:
+		return ""
+	}
+}
+
 // A Value is either a flag or a variable positional argument.
 type Value struct {
 	Flag         *Flag // Nil if positional argument.

--- a/options.go
+++ b/options.go
@@ -208,6 +208,25 @@ func ConfigureHelp(options HelpOptions) Option {
 	})
 }
 
+// Group holds metadata about a node group used when printing help.
+type Group struct {
+	// Title is displayed above the grouped nodes.
+	Title string
+	// Header is optional and displayed under the Title when non empty.
+	// It can be used to introduce the group's purpose to the user.
+	Header string
+}
+
+// Groups associates `group` field tags with their metadata.
+//
+// It can be used to provide a title or header to a node group.
+func Groups(groups map[string]Group) Option {
+	return OptionFunc(func(k *Kong) error {
+		k.groups = groups
+		return nil
+	})
+}
+
 // UsageOnError configures Kong to display context-sensitive usage if FatalIfErrorf is called with an error.
 func UsageOnError() Option {
 	return OptionFunc(func(k *Kong) error {

--- a/options.go
+++ b/options.go
@@ -208,19 +208,10 @@ func ConfigureHelp(options HelpOptions) Option {
 	})
 }
 
-// Group holds metadata about a node group used when printing help.
-type Group struct {
-	// Title is displayed above the grouped nodes.
-	Title string
-	// Header is optional and displayed under the Title when non empty.
-	// It can be used to introduce the group's purpose to the user.
-	Header string
-}
-
 // Groups associates `group` field tags with their metadata.
 //
-// It can be used to provide a title or header to a node group.
-func Groups(groups map[string]Group) Option {
+// It can be used to provide a title or header to a command or flag group.
+func Groups(groups []Group) Option {
 	return OptionFunc(func(k *Kong) error {
 		k.groups = groups
 		return nil


### PR DESCRIPTION
Fix #134

@alecthomas It is still lacking support for grouped flags, I wanted to check with you that this PR is welcome and on the right path first.

Here's what's implemented so far:

* Ungrouped commands are displayed first, under a "Command:" group.
* Each group is printed in order of appearance.
* Tree mode ignores group for now.
   * This part is not so easy to implement, maybe that's a reasonable limitation.

I think it could be useful to add some group metadata as well. In this case, the `group` tag would be a key referencing a declared Group metadata. We could store:

* The group title, in case it's long and to be able to modify it in only one spot.
  * Git headings are quite long, e.g. `start a working area (see also: git help tutorial)`
* A short help message displayed under the group title.
    ```
    Filtering:
    Options used to filter the items in the list.

        --name   Filter by name
        --color   Filter by color
    ```

I'm not sure what would be the best place for such metadata. Maybe an `Option`?