### PR TITLE
HelpOptions.NoDocToText help text wrapping option

### DIFF
--- a/help.go
+++ b/help.go
@@ -44,6 +44,9 @@ type HelpOptions struct {
 	// Place the flags after the commands listing.
 	FlagsLast bool
 
+	// Do not auto wrap text and respect user defined line breaks.
+	NoDocToText bool
+
 	// Indenter modulates the given prefix for the next layer in the tree view.
 	// The following exported templates can be used: kong.SpaceIndenter, kong.LineIndenter, kong.TreeIndenter
 	// The kong.SpaceIndenter will be used by default.
@@ -377,9 +380,12 @@ func (h *helpWriter) Write(w io.Writer) error {
 }
 
 func (h *helpWriter) Wrap(text string) {
-	w := bytes.NewBuffer(nil)
-	doc.ToText(w, strings.TrimSpace(text), "", "    ", h.width)
-	for _, line := range strings.Split(strings.TrimSpace(w.String()), "\n") {
+	if !h.HelpOptions.NoDocToText {
+		w := bytes.NewBuffer(nil)
+		doc.ToText(w, strings.TrimSpace(text), "", "    ", h.width)
+		text = w.String()
+	}
+	for _, line := range strings.Split(strings.TrimSpace(text), "\n") {
 		h.Print(line)
 	}
 }

--- a/helpwriter_test.go
+++ b/helpwriter_test.go
@@ -1,0 +1,43 @@
+package kong
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_helpWriterNoDocToText(t *testing.T) {
+	// NOTE: the space after the second break to check if noDocToTextMode
+	// respects the user expectation. The go doc.ToText method returns
+	// different results if a space is passed after a newline.
+	subject := "I am a short string\nand have my own line breaks\n and some info"
+	defaultMode := &helpWriter{
+		lines:       &([]string{}),
+		width:       80,
+		HelpOptions: HelpOptions{},
+	}
+	defaultMode.Wrap(subject)
+	require.NotNil(t, defaultMode.lines)
+	require.Equal(t, 3, len(*defaultMode.lines))
+	actual := *defaultMode.lines
+	assert.Equal(t, "I am a short string and have my own line breaks", actual[0])
+	assert.Equal(t, "", actual[1])
+	assert.Equal(t, "    and some info", actual[2])
+
+	noDocToTextMode := &helpWriter{
+		lines: &([]string{}),
+		width: 80,
+		HelpOptions: HelpOptions{
+			NoDocToText: true,
+		},
+	}
+	noDocToTextMode.Wrap(subject)
+	require.NotNil(t, noDocToTextMode.lines)
+	assert.Equal(t, 3, len(*noDocToTextMode.lines))
+	actual = *noDocToTextMode.lines
+	assert.Equal(t, "I am a short string", actual[0])
+	assert.Equal(t, "and have my own line breaks", actual[1])
+	assert.Equal(t, " and some info", actual[2])
+}


### PR DESCRIPTION
The modification allows full user control of the help layout.

- added option to HelpOptions
- added package level help test for helpWriter .wrap()

NOTE package level tests is needed for planned helpWriter mods to check variations and table driven tests