### PR TITLE
Add aliases to tree help output

### DIFF
--- a/help.go
+++ b/help.go
@@ -474,6 +474,9 @@ func (h *HelpOptions) CommandTree(node *Node, prefix string) (rows [][2]string) 
 	switch node.Type {
 	default:
 		nodeName += prefix + node.Name
+		if len(node.Aliases) != 0 {
+			nodeName += fmt.Sprintf(" (%s)", strings.Join(node.Aliases, ","))
+		}
 	case ArgumentNode:
 		nodeName += prefix + "<" + node.Name + ">"
 	}

--- a/help_test.go
+++ b/help_test.go
@@ -245,13 +245,13 @@ func TestHelpTree(t *testing.T) {
 			Other struct {
 				Other string `arg help:"other arg"`
 			} `arg help:"subcommand other"`
-		} `cmd help:"subcommand one" group:"Group A"` // Groups are ignored in trees
+		} `cmd help:"subcommand one" group:"Group A" aliases:"un,uno"` // Groups are ignored in trees
 
 		Two struct {
 			Three threeArg `arg help:"Sub-sub-arg."`
 
 			Four struct {
-			} `cmd help:"Sub-sub-command."`
+			} `cmd help:"Sub-sub-command." aliases:"for,fore"`
 		} `cmd help:"Another subcommand."`
 	}
 
@@ -285,14 +285,14 @@ Flags:
   -h, --help    Show context-sensitive help.
 
 Commands:
-  one          subcommand one
-  - thing      subcommand thing
-    - <arg>    argument
-  - <other>    subcommand other
+  one (un,uno)         subcommand one
+  - thing              subcommand thing
+    - <arg>            argument
+  - <other>            subcommand other
 
-  two          Another subcommand.
-  - <three>    Sub-sub-arg.
-  - four       Sub-sub-command.
+  two                  Another subcommand.
+  - <three>            Sub-sub-arg.
+  - four (for,fore)    Sub-sub-command.
 
 Run "test-app <command> --help" for more information on a command.
 `


### PR DESCRIPTION
Couldn't find a good example of how other tools format their command aliases, so just went with putting them in parens:

```
Usage: test-app <command>

A test app.

Flags:
  -h, --help    Show context-sensitive help.

Commands:
  one (un,uno)         subcommand one
  - thing              subcommand thing
    - <arg>            argument
  - <other>            subcommand other

  two                  Another subcommand.
  - <three>            Sub-sub-arg.
  - four (for,fore)    Sub-sub-command.

Run "test-app <command> --help" for more information on a command.
```