### PR TITLE
options: Add kong.ShortUsageOnError() option

### DIFF
--- a/help.go
+++ b/help.go
@@ -87,6 +87,21 @@ func DefaultHelpValueFormatter(value *Value) string {
 	}
 }
 
+// DefaultShortHelpPrinter is the default HelpPrinter for short help on error.
+func DefaultShortHelpPrinter(options HelpOptions, ctx *Context) error {
+	w := newHelpWriter(ctx, options)
+	cmd := ctx.Selected()
+	app := ctx.Model
+	if cmd == nil {
+		w.Printf("Usage: %s%s", app.Name, app.Summary())
+		w.Printf(`Run "%s --help" for more information.`, app.Name)
+	} else {
+		w.Printf("Usage: %s %s", app.Name, cmd.Summary())
+		w.Printf(`Run "%s --help" for more information.`, cmd.FullPath())
+	}
+	return w.Write(ctx.Stdout)
+}
+
 // DefaultHelpPrinter is the default HelpPrinter.
 func DefaultHelpPrinter(options HelpOptions, ctx *Context) error {
 	if ctx.Empty() {

--- a/options.go
+++ b/options.go
@@ -192,6 +192,17 @@ func Help(help HelpPrinter) Option {
 	})
 }
 
+// ShortHelp configures the short usage message.
+//
+// It should be used together with kong.ShortUsageOnError() to display a
+// custom short usage message on errors.
+func ShortHelp(shortHelp HelpPrinter) Option {
+	return OptionFunc(func(k *Kong) error {
+		k.shortHelp = shortHelp
+		return nil
+	})
+}
+
 // HelpFormatter configures how the help text is formatted.
 func HelpFormatter(helpFormatter HelpValueFormatter) Option {
 	return OptionFunc(func(k *Kong) error {
@@ -251,7 +262,17 @@ func ExplicitGroups(groups []Group) Option {
 // UsageOnError configures Kong to display context-sensitive usage if FatalIfErrorf is called with an error.
 func UsageOnError() Option {
 	return OptionFunc(func(k *Kong) error {
-		k.usageOnError = true
+		k.usageOnError = fullUsage
+		return nil
+	})
+}
+
+// ShortUsageOnError configures Kong to display context-sensitive short
+// usage if FatalIfErrorf is called with an error. The default short
+// usage message can be overridden with kong.ShortHelp(...).
+func ShortUsageOnError() Option {
+	return OptionFunc(func(k *Kong) error {
+		k.usageOnError = shortUsage
 		return nil
 	})
 }


### PR DESCRIPTION
Add `kong.ShortUsageOnError()` option similar to `kong.UsageOnError()`.
For a custom short usage message use `kong.ShortHelp(kong.HelpPrinter)`
Add tests for UsageOnError and ShortUsageOnError.

