### PR TITLE
Add support for negatable boolean flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ Tag                    | Description
 `required`             | If present, flag/arg is required.
 `optional`             | If present, flag/arg is optional.
 `hidden`               | If present, command or flag is hidden.
-`negatable`            | If present on a `bool` field, supports prefixing a flag with `--no-` to set flag to `false`
+`negatable`            | If present on a `bool` field, supports prefixing a flag with `--no-` to invert the default value
 `format:"X"`           | Format for parsing input, if supported.
 `sep:"X"`              | Separator for sequences (defaults to ","). May be `none` to disable splitting.
 `mapsep:"X"`           | Separator for maps (defaults to ";"). May be `none` to disable splitting.

--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ Tag                    | Description
 `required`             | If present, flag/arg is required.
 `optional`             | If present, flag/arg is optional.
 `hidden`               | If present, command or flag is hidden.
+`negatable`            | If present on a `bool` field, supports prefixing a flag with `--no-` to set flag to `false`
 `format:"X"`           | Format for parsing input, if supported.
 `sep:"X"`              | Separator for sequences (defaults to ","). May be `none` to disable splitting.
 `mapsep:"X"`           | Separator for maps (defaults to ";"). May be `none` to disable splitting.

--- a/context.go
+++ b/context.go
@@ -649,7 +649,7 @@ func (c *Context) parseFlag(flags []*Flag, match string) (err error) {
 		if flag.Short != 0 {
 			candidates = append(candidates, short)
 		}
-		if short != match && long != match && neg != match {
+		if short != match && long != match && !(match == neg && flag.Tag.Negatable) {
 			continue
 		}
 		// Found a matching flag.

--- a/context.go
+++ b/context.go
@@ -579,9 +579,6 @@ func (c *Context) getValue(value *Value) reflect.Value {
 		}
 		c.values[value] = v
 	}
-	if value.Flag != nil && value.Flag.Negated {
-		v.SetBool(false)
-	}
 	return v
 }
 
@@ -629,7 +626,12 @@ func (c *Context) Apply() (string, error) {
 			panic("unsupported path ?!")
 		}
 		if value != nil {
-			value.Apply(c.getValue(value))
+			v := c.getValue(value)
+			if value.Flag != nil && value.Flag.Negated {
+				v.SetBool(!v.Bool())
+			}
+
+			value.Apply(v)
 		}
 	}
 

--- a/context.go
+++ b/context.go
@@ -652,7 +652,7 @@ func (c *Context) parseFlag(flags []*Flag, match string) (err error) {
 		}
 		// Found a matching flag.
 		c.scan.Pop()
-		if flag.Value.IsBool() && match == neg {
+		if match == neg && flag.Tag.Negatable {
 			flag.Negated = true
 		}
 		err := flag.Parse(c.scan, c.getValue(flag.Value))

--- a/help.go
+++ b/help.go
@@ -472,9 +472,17 @@ func formatFlag(haveShort bool, flag *Flag) string {
 		flagString += fmt.Sprintf("-%c, --%s", flag.Short, name)
 	} else {
 		if haveShort {
-			flagString += fmt.Sprintf("    --%s", name)
+			if isBool && flag.Tag.Negatable {
+				flagString = fmt.Sprintf("    --[no-]%s", name)
+			} else {
+				flagString += fmt.Sprintf("    --%s", name)
+			}
 		} else {
-			flagString += fmt.Sprintf("--%s", name)
+			if isBool && flag.Tag.Negatable {
+				flagString = fmt.Sprintf("--[no-]%s", name)
+			} else {
+				flagString += fmt.Sprintf("--%s", name)
+			}
 		}
 	}
 	if !isBool {

--- a/help.go
+++ b/help.go
@@ -469,17 +469,21 @@ func formatFlag(haveShort bool, flag *Flag) string {
 	name := flag.Name
 	isBool := flag.IsBool()
 	if flag.Short != 0 {
-		flagString += fmt.Sprintf("-%c, --%s", flag.Short, name)
+		if isBool && flag.Tag.Negatable {
+			flagString += fmt.Sprintf("-%c, --[no-]%s", flag.Short, name)
+		} else {
+			flagString += fmt.Sprintf("-%c, --%s", flag.Short, name)
+		}
 	} else {
-		if haveShort {
-			if isBool && flag.Tag.Negatable {
+		if isBool && flag.Tag.Negatable {
+			if haveShort {
 				flagString = fmt.Sprintf("    --[no-]%s", name)
 			} else {
-				flagString += fmt.Sprintf("    --%s", name)
+				flagString = fmt.Sprintf("--[no-]%s", name)
 			}
 		} else {
-			if isBool && flag.Tag.Negatable {
-				flagString = fmt.Sprintf("--[no-]%s", name)
+			if haveShort {
+				flagString += fmt.Sprintf("    --%s", name)
 			} else {
 				flagString += fmt.Sprintf("--%s", name)
 			}

--- a/help_test.go
+++ b/help_test.go
@@ -29,7 +29,7 @@ func TestHelp(t *testing.T) {
 		Slice    []string       `help:"A slice of strings." placeholder:"STR"`
 		Map      map[string]int `help:"A map of strings to ints."`
 		Required bool           `required help:"A required flag."`
-		Sort     bool           `negatable help:"Is sortable or not."`
+		Sort     bool           `negatable short:"s" help:"Is sortable or not."`
 
 		One struct {
 			Flag string `help:"Nested flag."`
@@ -76,7 +76,7 @@ Flags:
       --slice=STR,...        A slice of strings.
       --map=KEY=VALUE;...    A map of strings to ints.
       --required             A required flag.
-      --[no-]sort            Is sortable or not.
+  -s, --[no-]sort            Is sortable or not.
 
 Commands:
   one --required
@@ -117,7 +117,7 @@ Flags:
       --slice=STR,...        A slice of strings.
       --map=KEY=VALUE;...    A map of strings to ints.
       --required             A required flag.
-      --[no-]sort            Is sortable or not.
+  -s, --[no-]sort            Is sortable or not.
 
       --flag=STRING          Nested flag under two.
       --required-two

--- a/help_test.go
+++ b/help_test.go
@@ -29,6 +29,7 @@ func TestHelp(t *testing.T) {
 		Slice    []string       `help:"A slice of strings." placeholder:"STR"`
 		Map      map[string]int `help:"A map of strings to ints."`
 		Required bool           `required help:"A required flag."`
+		Sort     bool           `negatable help:"Is sortable or not."`
 
 		One struct {
 			Flag string `help:"Nested flag."`
@@ -75,6 +76,7 @@ Flags:
       --slice=STR,...        A slice of strings.
       --map=KEY=VALUE;...    A map of strings to ints.
       --required             A required flag.
+      --[no-]sort            Is sortable or not.
 
 Commands:
   one --required
@@ -115,6 +117,7 @@ Flags:
       --slice=STR,...        A slice of strings.
       --map=KEY=VALUE;...    A map of strings to ints.
       --required             A required flag.
+      --[no-]sort            Is sortable or not.
 
       --flag=STRING          Nested flag under two.
       --required-two

--- a/kong_test.go
+++ b/kong_test.go
@@ -356,6 +356,19 @@ func TestTraceErrorPartiallySucceeds(t *testing.T) {
 	require.Equal(t, "one", ctx.Command())
 }
 
+func TestNegatedBooleanFlag(t *testing.T) {
+	var cli struct {
+		Cmd struct {
+			Flag bool `kong:"default='true'"`
+		} `kong:"cmd"`
+	}
+
+	p := mustNew(t, &cli)
+	_, err := p.Parse([]string{"cmd", "--no-flag"})
+	require.NoError(t, err)
+	require.Equal(t, false, cli.Cmd.Flag)
+}
+
 type hookContext struct {
 	cmd    bool
 	values []string

--- a/kong_test.go
+++ b/kong_test.go
@@ -369,6 +369,19 @@ func TestNegatedBooleanFlag(t *testing.T) {
 	require.Equal(t, false, cli.Cmd.Flag)
 }
 
+func TestInvertedNegatedBooleanFlag(t *testing.T) {
+	var cli struct {
+		Cmd struct {
+			Flag bool `kong:"default='true',negatable"`
+		} `kong:"cmd"`
+	}
+
+	p := mustNew(t, &cli)
+	_, err := p.Parse([]string{"cmd", "--no-flag=false"})
+	require.NoError(t, err)
+	require.Equal(t, true, cli.Cmd.Flag)
+}
+
 func TestInvalidNegatedNonBool(t *testing.T) {
 	var cli struct {
 		Cmd struct {

--- a/kong_test.go
+++ b/kong_test.go
@@ -359,7 +359,7 @@ func TestTraceErrorPartiallySucceeds(t *testing.T) {
 func TestNegatedBooleanFlag(t *testing.T) {
 	var cli struct {
 		Cmd struct {
-			Flag bool `kong:"default='true'"`
+			Flag bool `kong:"default='true',negatable"`
 		} `kong:"cmd"`
 	}
 
@@ -367,6 +367,17 @@ func TestNegatedBooleanFlag(t *testing.T) {
 	_, err := p.Parse([]string{"cmd", "--no-flag"})
 	require.NoError(t, err)
 	require.Equal(t, false, cli.Cmd.Flag)
+}
+
+func TestInvalidNegatedNonBool(t *testing.T) {
+	var cli struct {
+		Cmd struct {
+			Flag string `kong:"negatable"`
+		} `kong:"cmd"`
+	}
+
+	_, err := kong.New(&cli)
+	require.Error(t, err)
 }
 
 type hookContext struct {

--- a/kong_test.go
+++ b/kong_test.go
@@ -382,6 +382,21 @@ func TestInvertedNegatedBooleanFlag(t *testing.T) {
 	require.Equal(t, true, cli.Cmd.Flag)
 }
 
+func TestExistingNoFlag(t *testing.T) {
+	var cli struct {
+		Cmd struct {
+			Flag   bool `kong:"default='true'"`
+			NoFlag string
+		} `kong:"cmd"`
+	}
+
+	p := mustNew(t, &cli)
+	_, err := p.Parse([]string{"cmd", "--no-flag=none"})
+	require.NoError(t, err)
+	require.Equal(t, true, cli.Cmd.Flag)
+	require.Equal(t, "none", cli.Cmd.NoFlag)
+}
+
 func TestInvalidNegatedNonBool(t *testing.T) {
 	var cli struct {
 		Cmd struct {

--- a/model.go
+++ b/model.go
@@ -227,6 +227,7 @@ type Value struct {
 	Tag          *Tag
 	Target       reflect.Value
 	Required     bool
+	Negated      bool
 	Set          bool   // Set to true when this value is set through some mechanism.
 	Format       string // Formatting directive, if applicable.
 	Position     int    // Position (for positional arguments).

--- a/model.go
+++ b/model.go
@@ -227,7 +227,6 @@ type Value struct {
 	Tag          *Tag
 	Target       reflect.Value
 	Required     bool
-	Negated      bool
 	Set          bool   // Set to true when this value is set through some mechanism.
 	Format       string // Formatting directive, if applicable.
 	Position     int    // Position (for positional arguments).
@@ -370,6 +369,7 @@ type Flag struct {
 	Env         string
 	Short       rune
 	Hidden      bool
+	Negated     bool
 }
 
 func (f *Flag) String() string {

--- a/tag.go
+++ b/tag.go
@@ -33,6 +33,7 @@ type Tag struct {
 	Prefix      string // Optional prefix on anonymous structs. All sub-flags will have this prefix.
 	Embed       bool
 	Aliases     []string
+	Negatable   bool
 
 	// Storage for all tag keys for arbitrary lookups.
 	items map[string][]string
@@ -158,6 +159,11 @@ func parseTag(fv reflect.Value, ft reflect.StructField) *Tag {
 	t.Xor = t.Get("xor")
 	t.Prefix = t.Get("prefix")
 	t.Embed = t.Has("embed")
+	negatable := t.Has("negatable")
+	if negatable && ft.Type.Name() != "bool" {
+		fail("negatable can only be set on booleans")
+	}
+	t.Negatable = negatable
 	splitFn := func(r rune) bool {
 		return r == ',' || r == ' '
 	}

--- a/tag.go
+++ b/tag.go
@@ -160,7 +160,7 @@ func parseTag(fv reflect.Value, ft reflect.StructField) *Tag {
 	t.Prefix = t.Get("prefix")
 	t.Embed = t.Has("embed")
 	negatable := t.Has("negatable")
-	if negatable && ft.Type.Name() != "bool" {
+	if negatable && ft.Type.Kind() != reflect.Bool {
 		fail("negatable can only be set on booleans")
 	}
 	t.Negatable = negatable


### PR DESCRIPTION
Adds support for a new `negatable` struct tag, which will automatically set a boolean Struct flag value to `false` if the flag's name starts with `--no-`, even when the default is `true`. This idea is shamelessly stolen from the [`commander` npm library](https://github.com/tj/commander.js#other-option-types-negatable-boolean-and-booleanvalue)

For example:
```go
type Cmd struct {
  Sort bool `default:"true",negatable`
}
```

Calling
```sh
command
# or
command --sort
```
Will set `Sort` to `true`, but
```sh 
command --no-sort
```
Will set `Sort` to `false`.

## Why do this?

It avoids the situation of having to do:
```go
type Cmd struct {
  NoSort bool
}

func (c *Cmd) Run() error {
  if !c.NoSort {
    // Double negations are hard to read!
  }
  return nil
}
```