### PR TITLE
Allow `-` for stdout in path mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,8 +385,8 @@ function `NamedMapper(name, mapper)`.
 
 | Name              | Description
 |-------------------|---------------------------------------------------
-| `path`            | A path. ~ expansion is applied. `-` is accepted for stdout.
-| `existingfile`    | An existing file. ~ expansion is applied. `-` is accepted for stdin.
+| `path`            | A path. ~ expansion is applied. `-` is accepted for stdout, and will be passed unaltered.
+| `existingfile`    | An existing file. ~ expansion is applied. `-` is accepted for stdin, and will be passed unaltered.
 | `existingdir`     | An existing directory. ~ expansion is applied.
 | `counter`         | Increment a numeric field. Useful for `-vvv`. Can accept `-s`, `--long` or `--long=N`.
 

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ function `NamedMapper(name, mapper)`.
 
 | Name              | Description
 |-------------------|---------------------------------------------------
-| `path`            | A path. ~ expansion is applied.
+| `path`            | A path. ~ expansion is applied. `-` is accepted for stdout.
 | `existingfile`    | An existing file. ~ expansion is applied. `-` is accepted for stdin.
 | `existingdir`     | An existing directory. ~ expansion is applied.
 | `counter`         | Increment a numeric field. Useful for `-vvv`. Can accept `-s`, `--long` or `--long=N`.

--- a/mapper.go
+++ b/mapper.go
@@ -554,7 +554,9 @@ func pathMapper(r *Registry) MapperFunc {
 		if err != nil {
 			return err
 		}
-		path = ExpandPath(path)
+		if path != "-" {
+			path = ExpandPath(path)
+		}
 		target.SetString(path)
 		return nil
 	}

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -378,3 +378,18 @@ func TestFileMapper(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, os.Stdin, cli.File)
 }
+
+func TestPathMapper(t *testing.T) {
+	var cli struct {
+		Path string `arg:"" type:"path"`
+	}
+	p := mustNew(t, &cli)
+
+	_, err := p.Parse([]string{"/an/absolute/path"})
+	require.NoError(t, err)
+	require.Equal(t, "/an/absolute/path", cli.Path)
+
+	_, err = p.Parse([]string{"-"})
+	require.NoError(t, err)
+	require.Equal(t, "-", cli.Path)
+}


### PR DESCRIPTION
I passed `-` into a path flag, expecting to be able to special-case it to stdout in my command. Unfortunately it was expanded to an absolute file path and so my command wrote a file called `-` in the current working directory instead.

This can obviously be achieved with a custom mapper, but do you think it would it make sense to allow `-` in the path mapper by default?