### PR TITLE
mapper: correct text/binary typo (panic)

### DIFF
--- a/mapper.go
+++ b/mapper.go
@@ -84,7 +84,7 @@ func (m *binaryUnmarshalerAdapter) Decode(ctx *DecodeContext, target reflect.Val
 	if err != nil {
 		return err
 	}
-	if target.Type().Implements(textUnmarshalerType) {
+	if target.Type().Implements(binaryUnmarshalerType) {
 		return target.Interface().(encoding.BinaryUnmarshaler).UnmarshalBinary([]byte(value))
 	}
 	return target.Addr().Interface().(encoding.BinaryUnmarshaler).UnmarshalBinary([]byte(value))


### PR DESCRIPTION
I was reading through the source when I found what looked like a small copy-paste error.  Here's a trivial patch.  Thank you for these libraries, Alec.

`UnmarshalBinary` did seem to work OK on my first test.  It wasn't until I read the source more carefully that I realised the field must be a _pointer_ to a type that implements `UnmarshalBinary` in order to trigger a panic:

```go
package main

import (
	"errors"

	"github.com/alecthomas/kong"
)

type SomeTextFlag struct{}

func (f *SomeTextFlag) UnmarshalText(text []byte) error {
	return errors.New("hello from UnmarshalText")
}

type SomeBinaryFlag struct{}

func (f *SomeBinaryFlag) UnmarshalBinary(data []byte) error {
	return errors.New("hello from UnmarshalBinary")
}

var cli struct {
	Text   *SomeTextFlag
	Binary *SomeBinaryFlag
}

func main() {
	kong.Parse(&cli)
}
```

```
% ./test --binary foo
panic: interface conversion: **main.SomeBinaryFlag is not encoding.BinaryUnmarshaler: missing method UnmarshalBinary [recovered]
        panic: mapper *kong.binaryUnmarshalerAdapter failed to apply to --binary=BINARY: interface conversion: **main.SomeBinaryFlag is not encoding.BinaryUnmarshaler: missing method UnmarshalBinary [recovered]
        panic: mapper *kong.binaryUnmarshalerAdapter failed to apply to --binary=BINARY: interface conversion: **main.SomeBinaryFlag is not encoding.BinaryUnmarshaler: missing method UnmarshalBinary [recovered]
        panic: mapper *kong.binaryUnmarshalerAdapter failed to apply to --binary=BINARY: interface conversion: **main.SomeBinaryFlag is not encoding.BinaryUnmarshaler: missing method UnmarshalBinary

goroutine 1 [running]:
github.com/alecthomas/kong.catch(0xc000107f10)
        /Users/saj/Documents/src/go/pkg/mod/github.com/alecthomas/kong@v0.2.16/kong.go:383 +0xc5
panic(0x11693a0, 0xc00004c560)
        /usr/local/Cellar/go/1.16.1/libexec/src/runtime/panic.go:965 +0x1b9
github.com/alecthomas/kong.catch(0xc000107ae0)
        /Users/saj/Documents/src/go/pkg/mod/github.com/alecthomas/kong@v0.2.16/kong.go:383 +0xc5
panic(0x11693a0, 0xc00004c560)
        /usr/local/Cellar/go/1.16.1/libexec/src/runtime/panic.go:965 +0x1b9
github.com/alecthomas/kong.(*Value).Parse.func1(0xc000120160, 0xc000107948)
        /Users/saj/Documents/src/go/pkg/mod/github.com/alecthomas/kong@v0.2.16/model.go:309 +0x246
panic(0x1175d80, 0xc000012960)
        /usr/local/Cellar/go/1.16.1/libexec/src/runtime/panic.go:965 +0x1b9
github.com/alecthomas/kong.(*binaryUnmarshalerAdapter).Decode(0x12d3c70, 0xc00004c4e0, 0x1172340, 0xc000010098, 0x196, 0xc00000e198, 0x16)
        /Users/saj/Documents/src/go/pkg/mod/github.com/alecthomas/kong@v0.2.16/mapper.go:90 +0x231
github.com/alecthomas/kong.(*Value).Parse(0xc000120160, 0xc00000e120, 0x1172340, 0xc000010098, 0x196, 0x0, 0x0)
        /Users/saj/Documents/src/go/pkg/mod/github.com/alecthomas/kong@v0.2.16/model.go:313 +0xd4
github.com/alecthomas/kong.(*Context).parseFlag(0xc000134000, 0xc00000e168, 0x3, 0x3, 0xc000016308, 0x8, 0x0, 0x0)
        /Users/saj/Documents/src/go/pkg/mod/github.com/alecthomas/kong@v0.2.16/context.go:660 +0x385
github.com/alecthomas/kong.(*Context).trace(0xc000134000, 0xc00011e0e0, 0x2, 0xc00000e120)
        /Users/saj/Documents/src/go/pkg/mod/github.com/alecthomas/kong@v0.2.16/context.go:398 +0x143d
github.com/alecthomas/kong.Trace(0xc00011e000, 0xc0000121c0, 0x2, 0x2, 0xc0000260e0, 0x6, 0xc00004c380)
        /Users/saj/Documents/src/go/pkg/mod/github.com/alecthomas/kong@v0.2.16/context.go:101 +0x1aa
github.com/alecthomas/kong.(*Kong).Parse(0xc00011e000, 0xc0000121c0, 0x2, 0x2, 0x0, 0x0, 0x0)
        /Users/saj/Documents/src/go/pkg/mod/github.com/alecthomas/kong@v0.2.16/kong.go:211 +0x8f
github.com/alecthomas/kong.Parse(0x11652e0, 0x12a61e0, 0x0, 0x0, 0x0, 0xc0000240b8)
        /Users/saj/Documents/src/go/pkg/mod/github.com/alecthomas/kong@v0.2.16/global.go:13 +0xc8
main.main()
        /Users/saj/s/stash/shstash-335677514/main.go:27 +0x4a
```