### PR TITLE
Add ENV file resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,10 @@ eg.
 ```go
 kong.Parse(&cli, kong.Configuration(kong.JSON, "/etc/myapp.json", "~/.myapp.json"))
 ```
+or with .env file
+```go
+kong.Parse(&cli, kong.Configuration(kong.ENVFile, "./production.env", "./.dev.env"))
+```
 
 [See the tests](https://github.com/alecthomas/kong/blob/master/resolver_test.go#L103) for an example of how the JSON file is structured.
 

--- a/envfile.go
+++ b/envfile.go
@@ -1,0 +1,157 @@
+package kong
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+)
+
+// ParseENVFile reads an env file from io.Reader and returns a kay/value map
+func ParseENVFile(r io.Reader) (map[string]string, error) {
+	envMap := make(map[string]string)
+
+	var lines []string
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	err := scanner.Err()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't read an .env file: %w", err)
+	}
+
+	for _, fullLine := range lines {
+		if !isIgnoredLine(fullLine) {
+			var key, value string
+			key, value, err = parseLine(fullLine, envMap)
+
+			if err != nil {
+				return nil, fmt.Errorf("couldn't parse a line of an .env file: %w", err)
+			}
+			envMap[key] = value
+		}
+	}
+	return envMap, nil
+}
+
+func parseLine(line string, envMap map[string]string) (key string, value string, err error) {
+	if len(line) == 0 {
+		return "", "", errors.New("empty string")
+	}
+
+	line = uncommentLine(line)
+
+	splitString := strings.SplitN(line, "=", 2)
+	if len(splitString) != 2 {
+		return "", "", errors.New("couldn't separate key from value")
+	}
+
+	// Parse the key
+	key = splitString[0]
+	// Get rid of spaces and "export …"
+	key = strings.Trim(strings.TrimPrefix(key, "export"), " ")
+
+	// Parse the value
+	value = parseValue(splitString[1], envMap)
+	return key, value, nil
+}
+
+func parseValue(value string, envMap map[string]string) string {
+	value = strings.Trim(value, " ")
+	if len(value) <= 1 {
+		return value
+	}
+
+	// check if we've got quoted values or possible escapes
+	regexpSingle := regexp.MustCompile(`\A'(.*)'\z`)
+	singleQuotes := regexpSingle.FindStringSubmatch(value)
+
+	regexpDouble := regexp.MustCompile(`\A"(.*)"\z`)
+	doubleQuotes := regexpDouble.FindStringSubmatch(value)
+
+	if singleQuotes != nil || doubleQuotes != nil {
+		// Remove the quotes around the edge of the line
+		value = value[1 : len(value)-1]
+	}
+
+	if doubleQuotes != nil {
+		// expand newlines
+		escapeRegex := regexp.MustCompile(`\\.`)
+		value = escapeRegex.ReplaceAllStringFunc(value, func(match string) string {
+			c := strings.TrimPrefix(match, `\`)
+			switch c {
+			case "n":
+				return "\n"
+			case "r":
+				return "\r"
+			default:
+				return match
+			}
+		})
+		// unescape characters
+		e := regexp.MustCompile(`\\([^$])`)
+		value = e.ReplaceAllString(value, "$1")
+	}
+
+	if singleQuotes == nil {
+		value = expandVariables(value, envMap)
+	}
+
+	return value
+}
+
+func expandVariables(v string, m map[string]string) string {
+	r := regexp.MustCompile(`(\\)?(\$)(\()?\{?([A-Z0-9_]+)?\}?`)
+
+	return r.ReplaceAllStringFunc(v, func(s string) string {
+		submatch := r.FindStringSubmatch(s)
+
+		if submatch == nil {
+			return s
+		}
+		if submatch[1] == "\\" || submatch[2] == "(" {
+			return submatch[0][1:]
+		} else if submatch[4] != "" {
+			return m[submatch[4]]
+		}
+		return s
+	})
+}
+
+// uncommentLine removes commented segments from line
+func uncommentLine(line string) string {
+	if !strings.Contains(line, "#") {
+		return line
+	}
+
+	// Get rid of comment segments, but keep quoted # signs
+	segmentsBetweenHashes := strings.Split(line, "#")
+	quotesAreOpen := false
+	var segmentsToKeep []string
+	for _, segment := range segmentsBetweenHashes {
+		if strings.Count(segment, "\"") == 1 || strings.Count(segment, "'") == 1 {
+			if quotesAreOpen {
+				quotesAreOpen = false
+				segmentsToKeep = append(segmentsToKeep, segment)
+			} else {
+				quotesAreOpen = true
+			}
+		}
+
+		if len(segmentsToKeep) == 0 || quotesAreOpen {
+			segmentsToKeep = append(segmentsToKeep, segment)
+		}
+	}
+
+	return strings.Join(segmentsToKeep, "#")
+}
+
+// isIgnoredLine checks whether line is a comment
+func isIgnoredLine(line string) bool {
+	trimmedLine := strings.Trim(line, " \n\t")
+	return len(trimmedLine) == 0 || strings.HasPrefix(trimmedLine, "#")
+}

--- a/envfile_test.go
+++ b/envfile_test.go
@@ -1,0 +1,119 @@
+package kong_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/alecthomas/kong"
+)
+
+func TestParseENVFile(t *testing.T) {
+	tests := []struct {
+		name                 string
+		input                string
+		expected             map[string]string
+		expectedErrorMessage string
+	}{
+		{
+			name:                 "Empty input",
+			input:                "",
+			expected:             map[string]string{},
+			expectedErrorMessage: "",
+		},
+		{
+			name:  "Single simple string",
+			input: "OPTION_A=Text 1",
+			expected: map[string]string{
+				"OPTION_A": "Text 1",
+			},
+			expectedErrorMessage: "",
+		},
+		{
+			name:  "Single string with export clause",
+			input: "export OPTION_A=Text 1",
+			expected: map[string]string{
+				"OPTION_A": "Text 1",
+			},
+			expectedErrorMessage: "",
+		},
+		{
+			name: "Multiple strings",
+			input: "OPTION_A=Text 1\n" +
+				"OPTION_B=Some other text",
+			expected: map[string]string{
+				"OPTION_A": "Text 1",
+				"OPTION_B": "Some other text",
+			},
+			expectedErrorMessage: "",
+		},
+		{
+			name: "Multiple strings with commented lines",
+			input: "OPTION_A=Text 1\n" +
+				"# Comment line\n" +
+				"OPTION_B=Some other text",
+			expected: map[string]string{
+				"OPTION_A": "Text 1",
+				"OPTION_B": "Some other text",
+			},
+			expectedErrorMessage: "",
+		},
+		{
+			name: "Multiple strings with a comment in the end of a line",
+			input: "OPTION_A=Text 1\n" +
+				"OPTION_B=Some other text # commented segment",
+			expected: map[string]string{
+				"OPTION_A": "Text 1",
+				"OPTION_B": "Some other text",
+			},
+			expectedErrorMessage: "",
+		},
+		{
+			name: "Multiple strings with double quotes",
+			input: "OPTION_A=Text 1\n" +
+				"OPTION_B=\"Some other text # not comment anymore\"",
+			expected: map[string]string{
+				"OPTION_A": "Text 1",
+				"OPTION_B": "Some other text # not comment anymore",
+			},
+			expectedErrorMessage: "",
+		},
+		{
+			name: "Multiple strings with single quotes",
+			input: "OPTION_A=Text 1\n" +
+				"OPTION_B='Some other text # not comment anymore'",
+			expected: map[string]string{
+				"OPTION_A": "Text 1",
+				"OPTION_B": "Some other text # not comment anymore",
+			},
+			expectedErrorMessage: "",
+		},
+		{
+			name: "Multiple strings with substitution",
+			input: "OPTION_A=Text 1\n" +
+				"OPTION_B=\"$OPTION_A -> Some other text # not comment anymore\"",
+			expected: map[string]string{
+				"OPTION_A": "Text 1",
+				"OPTION_B": "Text 1 -> Some other text # not comment anymore",
+			},
+			expectedErrorMessage: "",
+		},
+	}
+
+	for i := range tests {
+		tt := tests[i]
+		t.Run(tt.name, func(t *testing.T) {
+			reader := strings.NewReader(tt.input)
+			actual, err := kong.ParseENVFile(reader)
+			switch tt.expectedErrorMessage {
+			case "":
+				require.NoError(t, err)
+				require.EqualValues(t, tt.expected, actual)
+			default:
+				require.Error(t, err, tt.expectedErrorMessage)
+				require.Empty(t, actual)
+			}
+		})
+	}
+}

--- a/resolver.go
+++ b/resolver.go
@@ -47,3 +47,23 @@ func JSON(r io.Reader) (Resolver, error) {
 
 	return f, nil
 }
+
+// ENVFile returns a Resolver that retrieves values from a .env file source.
+//
+// ENVFile resolves only flags with `env:"X"` tag.
+func ENVFile(r io.Reader) (Resolver, error) {
+	values, err := ParseENVFile(r)
+	if err != nil {
+		return nil, err
+	}
+
+	var f ResolverFunc = func(context *Context, parent *Path, flag *Flag) (interface{}, error) {
+		raw, ok := values[flag.Env]
+		if !ok {
+			return nil, nil
+		}
+		return raw, nil
+	}
+
+	return f, nil
+}

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -243,3 +243,51 @@ func TestValidatingResolverErrors(t *testing.T) {
 	_, err := mustNew(t, &cli, kong.Resolvers(resolver)).Parse(nil)
 	require.EqualError(t, err, "invalid")
 }
+
+func TestParseENVFileBasic(t *testing.T) {
+	var cli struct {
+		String string `env:"STRING"`
+		Int    int    `env:"INT"`
+		Bool   bool   `env:"BOOL"`
+	}
+
+	envFlie := `STRING=🍕
+INT=5
+BOOL=true
+`
+
+	r, err := kong.ENVFile(strings.NewReader(envFlie))
+	require.NoError(t, err)
+
+	parser := mustNew(t, &cli, kong.Resolvers(r))
+	_, err = parser.Parse([]string{})
+	require.NoError(t, err)
+	require.Equal(t, "🍕", cli.String)
+	require.Equal(t, 5, cli.Int)
+	require.True(t, cli.Bool)
+}
+
+func TestParseENVFileSubstitutions(t *testing.T) {
+	var cli struct {
+		String  string `env:"STRING"`
+		Int     int    `env:"INT"`
+		Bool    bool   `env:"BOOL"`
+		String2 string `env:"STRING_2"`
+	}
+
+	envFlie := `STRING=🍕
+INT=5
+BOOL=true
+STRING_2=$STRING
+`
+
+	r, err := kong.ENVFile(strings.NewReader(envFlie))
+	require.NoError(t, err)
+
+	parser := mustNew(t, &cli, kong.Resolvers(r))
+	_, err = parser.Parse([]string{})
+	require.NoError(t, err)
+	require.Equal(t, "🍕", cli.String)
+	require.Equal(t, 5, cli.Int)
+	require.True(t, cli.Bool)
+}


### PR DESCRIPTION
I've added a configuration resolver for .env files. I used https://github.com/joho/godotenv as a reference.

Example of .env file:
```env
VARIABLE_1=Some simple text here # all comment segments will be trimmed
# comment line will be removed as well
export VARIABLE_2=You can also use "export" word as a prefix
VARIABLE_3 = "Surrounded variable in double quotes"
VARIABLE_4 = 'Surrounded variable in single quotes'
VARIABLE_5 = $VARIABLE_1 + some extra text # $VARIABLE_1 will be replaced with variable's value
```

Example of configuration:
```golang
type App struct {
	EnvFile   kong.ConfigFlag  `kong:"optional,name=env-file,help='Path to .env file'"`
}
func main() {
	var app App
	ctx := kong.Parse(&app, kong.Configuration(kong.ENVFile))
	ctx.FatalIfErrorf(ctx.Run())
}
```