### PR TITLE
fix panic resolver's configuration file does not have read permission

### DIFF
--- a/options.go
+++ b/options.go
@@ -329,9 +329,16 @@ func Configuration(loader ConfigurationLoader, paths ...string) Option {
 	return OptionFunc(func(k *Kong) error {
 		k.loader = loader
 		for _, path := range paths {
-			if _, err := os.Stat(ExpandPath(path)); os.IsNotExist(err) {
-				continue
+			f, err := os.Open(ExpandPath(path))
+			if err != nil {
+				if os.IsNotExist(err) || os.IsPermission(err) {
+					continue
+				}
+
+				return err
 			}
+			f.Close()
+
 			resolver, err := k.LoadConfig(path)
 			if err != nil {
 				return errors.Wrap(err, path)


### PR DESCRIPTION
Without this fix you get the following panic when a resolver's file is not readable:

```console
command --help
panic: ~/.config/command/config.yaml: open /home/user/.config/command/config.yaml: permission denied

goroutine 1 [running]:
github.com/alecthomas/kong.Parse(0xacf6c0, 0xc0000b8900, 0xc0000b0300, 0x8, 0x8, 0x22)
        /home/rz/golang/pkg/mod/github.com/alecthomas/kong@v0.2.16/global.go:11 +0x145
main.main()
```

The easiest way for read permission is via `os.Open`