### PR TITLE
Fixes #125: Support custom per-mapper placeholder text

### DIFF
--- a/help.go
+++ b/help.go
@@ -67,7 +67,7 @@ type HelpProvider interface {
 
 // PlaceHolderProvider can be implemented by mappers to provide custom placeholder text.
 type PlaceHolderProvider interface {
-	PlaceHolder() string
+	PlaceHolder(flag *Flag) string
 }
 
 // HelpIndenter is used to indent new layers in the help tree.

--- a/help.go
+++ b/help.go
@@ -65,6 +65,11 @@ type HelpProvider interface {
 	Help() string
 }
 
+// PlaceHolderProvider can be implemented by mappers to provide custom placeholder text.
+type PlaceHolderProvider interface {
+	PlaceHolder() string
+}
+
 // HelpIndenter is used to indent new layers in the help tree.
 type HelpIndenter func(prefix string) string
 

--- a/mapper.go
+++ b/mapper.go
@@ -43,6 +43,7 @@ func (r *DecodeContext) WithScanner(scan *Scanner) *DecodeContext {
 }
 
 // MapperValue may be implemented by fields in order to provide custom mapping.
+// Mappers may additionally implement PlaceHolderProvider to provide custom placeholder text.
 type MapperValue interface {
 	Decode(ctx *DecodeContext) error
 }

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -449,6 +449,6 @@ func (t testMapperWithPlaceHolder) Decode(ctx *kong.DecodeContext, target reflec
 	return nil
 }
 
-func (t testMapperWithPlaceHolder) PlaceHolder() string {
+func (t testMapperWithPlaceHolder) PlaceHolder(flag *kong.Flag) string {
 	return "/a/b/c"
 }

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -420,3 +420,35 @@ func TestPathMapper(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "-", cli.Path)
 }
+
+func TestMapperPlaceHolder(t *testing.T) {
+	var cli struct {
+		Flag string
+	}
+	b := bytes.NewBuffer(nil)
+	k := mustNew(
+		t,
+		&cli,
+		kong.Writers(b, b),
+		kong.ValueMapper(&cli.Flag, testMapperWithPlaceHolder{}),
+		kong.Exit(func(int) { panic("exit") }),
+	)
+	// Ensure that --help
+	require.Panics(t, func() {
+		_, err := k.Parse([]string{"--help"})
+		require.NoError(t, err)
+	})
+	require.Contains(t, b.String(), "--flag=/a/b/c")
+}
+
+type testMapperWithPlaceHolder struct {
+}
+
+func (t testMapperWithPlaceHolder) Decode(ctx *kong.DecodeContext, target reflect.Value) error {
+	target.SetString("hi")
+	return nil
+}
+
+func (t testMapperWithPlaceHolder) PlaceHolder() string {
+	return "/a/b/c"
+}

--- a/model.go
+++ b/model.go
@@ -397,6 +397,10 @@ func (f *Flag) String() string {
 
 // FormatPlaceHolder formats the placeholder string for a Flag.
 func (f *Flag) FormatPlaceHolder() string {
+	placeholderHelper, ok := f.Value.Mapper.(PlaceHolderProvider)
+	if ok {
+		return placeholderHelper.PlaceHolder()
+	}
 	tail := ""
 	if f.Value.IsSlice() && f.Value.Tag.Sep != -1 {
 		tail += string(f.Value.Tag.Sep) + "..."

--- a/model.go
+++ b/model.go
@@ -399,7 +399,7 @@ func (f *Flag) String() string {
 func (f *Flag) FormatPlaceHolder() string {
 	placeholderHelper, ok := f.Value.Mapper.(PlaceHolderProvider)
 	if ok {
-		return placeholderHelper.PlaceHolder()
+		return placeholderHelper.PlaceHolder(f)
 	}
 	tail := ""
 	if f.Value.IsSlice() && f.Value.Tag.Sep != -1 {


### PR DESCRIPTION
Fixes #125 

This allows things like having the placeholder text be `--config=/path/to/file or "-"` or listing enumerations like `--level=trace|debug|info|warn`, dates like `--start-time="2000-11-01 23:00:00"` etc.  None of these are implemented out of the box - this is only for new custom mappers.

To use this implement the `PlaceHolderProvider` interface along with `MapperValue`.  Implementing that interface is optional, the default placeholder will be used otherwise.