### PR TITLE
Fix issue with negatable flag being negated twice

### DIFF
--- a/context.go
+++ b/context.go
@@ -635,12 +635,7 @@ func (c *Context) Apply() (string, error) {
 			panic("unsupported path ?!")
 		}
 		if value != nil {
-			v := c.getValue(value)
-			if value.Flag != nil && value.Flag.Negated {
-				v.SetBool(!v.Bool())
-			}
-
-			value.Apply(v)
+			value.Apply(c.getValue(value))
 		}
 	}
 
@@ -672,6 +667,11 @@ func (c *Context) parseFlag(flags []*Flag, match string) (err error) {
 				return errors.Errorf("%s; perhaps try %s=%q?", err, flag.ShortSummary(), e.token)
 			}
 			return err
+		}
+		if flag.Negated {
+			value := c.getValue(flag.Value)
+			value.SetBool(!value.Bool())
+			flag.Value.Apply(value)
 		}
 		c.Path = append(c.Path, &Path{Flag: flag})
 		return nil

--- a/kong_test.go
+++ b/kong_test.go
@@ -399,6 +399,7 @@ func TestNegatableFlag(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			var cli struct {
 				Cmd commandWithNegatableFlag `kong:"cmd"`


### PR DESCRIPTION
Fixes https://github.com/alecthomas/kong/issues/170

The logic of negating boolean flag value was added inside [Context.Apply()](https://github.com/alecthomas/kong/blob/master/context.go#L640) method, which is executed both for `Parse` and `Run` calls. This led to the negated flag value being parsed properly, but being negated again during the call to `Run`.