### PR TITLE
Add an option to clamp the help wrap width

### DIFF
--- a/help.go
+++ b/help.go
@@ -51,6 +51,11 @@ type HelpOptions struct {
 
 	// Don't show the help associated with subcommands
 	NoExpandSubcommands bool
+
+	// Clamp the help wrap width to a value smaller than the terminal width.
+	// If this is set to a non-positive number, the terminal width is used; otherwise,
+	// the min of this value or the terminal width is used.
+	WrapUpperBound int
 }
 
 // Apply options to Kong as a configuration option.
@@ -367,9 +372,13 @@ type helpWriter struct {
 
 func newHelpWriter(ctx *Context, options HelpOptions) *helpWriter {
 	lines := []string{}
+	wrapWidth := guessWidth(ctx.Stdout)
+	if options.WrapUpperBound > 0 && wrapWidth > options.WrapUpperBound {
+		wrapWidth = options.WrapUpperBound
+	}
 	w := &helpWriter{
 		indent:        "",
-		width:         guessWidth(ctx.Stdout),
+		width:         wrapWidth,
 		lines:         &lines,
 		helpFormatter: ctx.Kong.helpFormatter,
 		HelpOptions:   options,

--- a/help_test.go
+++ b/help_test.go
@@ -708,3 +708,38 @@ test: error: missing flags: --flag=STRING
 `
 	require.Equal(t, expected, w.String())
 }
+
+func TestCustomWrap(t *testing.T) {
+	var cli struct {
+		Flag string `help:"A string flag with very long help that wraps a lot and is verbose and is really verbose."`
+	}
+
+	w := bytes.NewBuffer(nil)
+	app := mustNew(t, &cli,
+		kong.Name("test-app"),
+		kong.Description("A test app."),
+		kong.HelpOptions{
+			WrapUpperBound: 50,
+		},
+		kong.Writers(w, w),
+		kong.Exit(func(int) {}),
+	)
+
+	_, err := app.Parse([]string{"--help"})
+	require.NoError(t, err)
+	expected := `Usage: test-app
+
+A test app.
+
+Flags:
+  -h, --help           Show context-sensitive
+                       help.
+      --flag=STRING    A string flag with very
+                       long help that wraps a lot
+                       and is verbose and is
+                       really verbose.
+`
+	t.Log(w.String())
+	t.Log(expected)
+	require.Equal(t, expected, w.String())
+}


### PR DESCRIPTION
This is nice to have because on really wide screens the default
terminal-width wrapping can be a little unpleasant to read.