### PR TITLE
Environment option

### DIFF
--- a/options.go
+++ b/options.go
@@ -386,7 +386,7 @@ func siftStrings(ss []string, filter func(s string) bool) []string {
 
 // DefaultEnvars option inits environment names for flags.
 // The name will not generate if tag "env" is "-".
-// Predefined environment variables are skiped.
+// Predefined environment variables are skipped.
 //
 // For example:
 //   --some.value -> PREFIX_SOME_VALUE

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -107,6 +107,15 @@ func TestEnv(t *testing.T) {
 
 	var cli Cli
 
+	expected := Cli{
+		One:   Embed{Flag: "one"},
+		Two:   Embed{Flag: "two"},
+		Three: Embed{Flag: "three"},
+		Four:  Embed{Flag: "four"},
+		Five:  true,
+	}
+
+	// With the prefix
 	parser, unsetEnvs := newEnvParser(t, &cli, envMap{
 		"KONG_ONE_FLAG":   "one",
 		"KONG_TWO_FLAG":   "two",
@@ -114,18 +123,27 @@ func TestEnv(t *testing.T) {
 		"KONG_FOUR_FLAG":  "four",
 		"KONG_FIVE":       "true",
 		"KONG_SIX":        "true",
-	}, kong.Env("KONG"))
+	}, kong.DefaultEnvars("KONG"))
 	defer unsetEnvs()
 
 	_, err := parser.Parse(nil)
 	require.NoError(t, err)
-	require.Equal(t, Cli{
-		One:   Embed{Flag: "one"},
-		Two:   Embed{Flag: "two"},
-		Three: Embed{Flag: "three"},
-		Four:  Embed{Flag: "four"},
-		Five:  true,
-	}, cli)
+	require.Equal(t, expected, cli)
+
+	// Without the prefix
+	parser, unsetEnvs = newEnvParser(t, &cli, envMap{
+		"ONE_FLAG":   "one",
+		"TWO_FLAG":   "two",
+		"THREE_FLAG": "three",
+		"FOUR_FLAG":  "four",
+		"FIVE":       "true",
+		"SIX":        "true",
+	}, kong.DefaultEnvars(""))
+	defer unsetEnvs()
+
+	_, err = parser.Parse(nil)
+	require.NoError(t, err)
+	require.Equal(t, expected, cli)
 }
 
 func TestJSONBasic(t *testing.T) {

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -26,10 +26,10 @@ func tempEnv(env envMap) func() {
 	}
 }
 
-func newEnvParser(t *testing.T, cli interface{}, env envMap) (*kong.Kong, func()) {
+func newEnvParser(t *testing.T, cli interface{}, env envMap, options ...kong.Option) (*kong.Kong, func()) {
 	t.Helper()
 	restoreEnv := tempEnv(env)
-	parser := mustNew(t, cli)
+	parser := mustNew(t, cli, options...)
 	return parser, restoreEnv
 }
 
@@ -90,6 +90,42 @@ func TestEnvarsWithDefault(t *testing.T) {
 	_, err = parser.Parse(nil)
 	require.NoError(t, err)
 	require.Equal(t, "moo", cli.Flag)
+}
+
+func TestEnv(t *testing.T) {
+	type Embed struct {
+		Flag string
+	}
+	type Cli struct {
+		One   Embed `prefix:"one-" embed:""`
+		Two   Embed `prefix:"two." embed:""`
+		Three Embed `prefix:"three_" embed:""`
+		Four  Embed `prefix:"four_" embed:""`
+		Five  bool
+		Six   bool `env:"-"`
+	}
+
+	var cli Cli
+
+	parser, unsetEnvs := newEnvParser(t, &cli, envMap{
+		"KONG_ONE_FLAG":   "one",
+		"KONG_TWO_FLAG":   "two",
+		"KONG_THREE_FLAG": "three",
+		"KONG_FOUR_FLAG":  "four",
+		"KONG_FIVE":       "true",
+		"KONG_SIX":        "true",
+	}, kong.Env("KONG"))
+	defer unsetEnvs()
+
+	_, err := parser.Parse(nil)
+	require.NoError(t, err)
+	require.Equal(t, Cli{
+		One:   Embed{Flag: "one"},
+		Two:   Embed{Flag: "two"},
+		Three: Embed{Flag: "three"},
+		Four:  Embed{Flag: "four"},
+		Five:  true,
+	}, cli)
 }
 
 func TestJSONBasic(t *testing.T) {


### PR DESCRIPTION
Generating environment variable names for flags.

```go
type Some {
    Value string
}

cli := struct {
    Some  Some `prefix:"some." embed:""`
}
kong.Parse(root, kong.Env("PREFIX"))
```

Generates:
``    --some.value -> PREFIX_SOME_VALUE
``

