### PR TITLE
Add ability to ignore fields that match given regex pattern(s)

### DIFF
--- a/build.go
+++ b/build.go
@@ -24,6 +24,7 @@ func build(k *Kong, ast interface{}) (app *Application, err error) {
 	for _, flag := range extraFlags {
 		seenFlags[flag.Name] = true
 	}
+
 	node, err := buildNode(k, iv, ApplicationNode, seenFlags)
 	if err != nil {
 		return nil, err
@@ -112,7 +113,17 @@ func buildNode(k *Kong, v reflect.Value, typ NodeType, seenFlags map[string]bool
 	if err != nil {
 		return nil, err
 	}
+
+	MAIN:
 	for _, field := range fields {
+		for _, r := range k.ignoreFieldsRegex {
+			if r.Match([]byte(field.field.Name)) {
+				fmt.Println("skipping field: ", field.field.Name)
+
+				continue MAIN
+			}
+		}
+
 		ft := field.field
 		fv := field.value
 

--- a/build.go
+++ b/build.go
@@ -114,12 +114,10 @@ func buildNode(k *Kong, v reflect.Value, typ NodeType, seenFlags map[string]bool
 		return nil, err
 	}
 
-	MAIN:
+MAIN:
 	for _, field := range fields {
 		for _, r := range k.ignoreFieldsRegex {
-			if r.Match([]byte(field.field.Name)) {
-				fmt.Println("skipping field: ", field.field.Name)
-
+			if r.MatchString(v.Type().Name() + "." + field.field.Name) {
 				continue MAIN
 			}
 		}

--- a/kong.go
+++ b/kong.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"strings"
 )
 
@@ -48,10 +49,11 @@ type Kong struct {
 	Stdout io.Writer
 	Stderr io.Writer
 
-	bindings  bindings
-	loader    ConfigurationLoader
-	resolvers []Resolver
-	registry  *Registry
+	bindings          bindings
+	loader            ConfigurationLoader
+	resolvers         []Resolver
+	registry          *Registry
+	ignoreFieldsRegex []*regexp.Regexp
 
 	noDefaultHelp bool
 	usageOnError  usageOnError
@@ -73,13 +75,14 @@ type Kong struct {
 // See the README (https://github.com/alecthomas/kong) for usage instructions.
 func New(grammar interface{}, options ...Option) (*Kong, error) {
 	k := &Kong{
-		Exit:          os.Exit,
-		Stdout:        os.Stdout,
-		Stderr:        os.Stderr,
-		registry:      NewRegistry().RegisterDefaults(),
-		vars:          Vars{},
-		bindings:      bindings{},
-		helpFormatter: DefaultHelpValueFormatter,
+		Exit:              os.Exit,
+		Stdout:            os.Stdout,
+		Stderr:            os.Stderr,
+		registry:          NewRegistry().RegisterDefaults(),
+		vars:              Vars{},
+		bindings:          bindings{},
+		helpFormatter:     DefaultHelpValueFormatter,
+		ignoreFieldsRegex: make([]*regexp.Regexp, 0),
 	}
 
 	options = append(options, Bind(k))

--- a/kong_test.go
+++ b/kong_test.go
@@ -1298,7 +1298,7 @@ func TestHydratePointerCommands(t *testing.T) {
 	require.Equal(t, &cmd{Flag: true}, cli.Cmd)
 }
 
-//nolint
+// nolint
 type testIgnoreFields struct {
 	Foo struct {
 		Bar bool

--- a/options.go
+++ b/options.go
@@ -326,14 +326,19 @@ func Resolvers(resolvers ...Resolver) Option {
 //
 // Example: When referencing protoc generated structs, you will likely want to
 // ignore/skip XXX_* fields.
-func IgnoreFieldsRegex(regexes ...*regexp.Regexp) Option {
+func IgnoreFieldsRegex(regexes ...string) Option {
 	return OptionFunc(func(k *Kong) error {
 		for _, r := range regexes {
-			if r == nil {
-				continue
+			if r == "" {
+				return errors.New("regex input cannot be empty")
 			}
 
-			k.ignoreFieldsRegex = append(k.ignoreFieldsRegex, r)
+			re, err := regexp.Compile(r)
+			if err != nil {
+				return errors.Wrap(err, "unable to compile regex")
+			}
+
+			k.ignoreFieldsRegex = append(k.ignoreFieldsRegex, re)
 		}
 
 		return nil

--- a/options.go
+++ b/options.go
@@ -6,6 +6,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -315,6 +316,26 @@ func ClearResolvers() Option {
 func Resolvers(resolvers ...Resolver) Option {
 	return OptionFunc(func(k *Kong) error {
 		k.resolvers = append(k.resolvers, resolvers...)
+		return nil
+	})
+}
+
+// IgnoreFieldsRegex will cause kong.New() to skip field names that match any
+// of the provided regex patterns. This is useful if you are not able to add a
+// kong="-" struct tag to a struct/element before the call to New.
+//
+// Example: When referencing protoc generated structs, you will likely want to
+// ignore/skip XXX_* fields.
+func IgnoreFieldsRegex(regexes ...*regexp.Regexp) Option {
+	return OptionFunc(func(k *Kong) error {
+		for _, r := range regexes {
+			if r == nil {
+				continue
+			}
+
+			k.ignoreFieldsRegex = append(k.ignoreFieldsRegex, r)
+		}
+
 		return nil
 	})
 }


### PR DESCRIPTION
@alecthomas this adds functionality to allow kong to ignore fields that match a certain pattern.

I needed this in order to be able to ensure that kong does not parse fields like `XXX_` that are automatically generated via protoc.

The regexp is kind of a big hammer but since this is for CLI generation, I figure the perf hit is OK. LMK.