### PR TITLE
Only prepend EnvPrefix if .Env is not empty.

### DIFF
--- a/build.go
+++ b/build.go
@@ -139,7 +139,9 @@ MAIN:
 			name = tag.Prefix + name
 		}
 
-		tag.Env = tag.EnvPrefix + tag.Env
+		if tag.Env != "" {
+			tag.Env = tag.EnvPrefix + tag.Env
+		}
 
 		// Nested structs are either commands or args, unless they implement the Mapper interface.
 		if field.value.Kind() == reflect.Struct && (tag.Cmd || tag.Arg) && k.registry.ForValue(fv) == nil {

--- a/help_test.go
+++ b/help_test.go
@@ -463,7 +463,8 @@ func TestEnvarAutoHelp(t *testing.T) {
 
 func TestEnvarAutoHelpWithEnvPrefix(t *testing.T) {
 	type Anonymous struct {
-		Flag string `env:"FLAG" help:"A flag."`
+		Flag  string `env:"FLAG" help:"A flag."`
+		Other string `help:"A different flag."`
 	}
 	var cli struct {
 		Anonymous `envprefix:"ANON_"`
@@ -473,6 +474,7 @@ func TestEnvarAutoHelpWithEnvPrefix(t *testing.T) {
 	_, err := p.Parse([]string{"--help"})
 	require.NoError(t, err)
 	require.Contains(t, w.String(), "A flag ($ANON_FLAG).")
+	require.Contains(t, w.String(), "A different flag.")
 }
 
 func TestCustomHelpFormatter(t *testing.T) {


### PR DESCRIPTION
Before this change the EnvPrefix was applied to fields without env
specified, which resulted in strange and confusing help output.