### PR TITLE
feat: add support for variable interpolation into env tag key

### DIFF
--- a/kong.go
+++ b/kong.go
@@ -186,20 +186,24 @@ func (k *Kong) interpolateValue(value *Value, vars Vars) (err error) {
 	if varsContributor, ok := value.Mapper.(VarsContributor); ok {
 		vars = vars.CloneWith(varsContributor.Vars(value))
 	}
+
+	updatedVars := map[string]string{
+		"default": value.Default,
+		"enum":    value.Enum,
+	}
 	if value.Default, err = interpolate(value.Default, vars, nil); err != nil {
 		return fmt.Errorf("default value for %s: %s", value.Summary(), err)
 	}
 	if value.Enum, err = interpolate(value.Enum, vars, nil); err != nil {
 		return fmt.Errorf("enum value for %s: %s", value.Summary(), err)
 	}
-	if value.Flag.Env, err = interpolate(value.Flag.Env, vars, nil); err != nil {
-		return fmt.Errorf("env value for %s: %s", value.Summary(), err)
+	if value.Flag != nil {
+		if value.Flag.Env, err = interpolate(value.Flag.Env, vars, nil); err != nil {
+			return fmt.Errorf("env value for %s: %s", value.Summary(), err)
+		}
+		updatedVars["env"] = value.Flag.Env
 	}
-	value.Help, err = interpolate(value.Help, vars, map[string]string{
-		"default": value.Default,
-		"enum":    value.Enum,
-		"env":     value.Flag.Env,
-	})
+	value.Help, err = interpolate(value.Help, vars, updatedVars)
 	if err != nil {
 		return fmt.Errorf("help for %s: %s", value.Summary(), err)
 	}

--- a/kong.go
+++ b/kong.go
@@ -192,9 +192,13 @@ func (k *Kong) interpolateValue(value *Value, vars Vars) (err error) {
 	if value.Enum, err = interpolate(value.Enum, vars, nil); err != nil {
 		return fmt.Errorf("enum value for %s: %s", value.Summary(), err)
 	}
+	if value.Flag.Env, err = interpolate(value.Flag.Env, vars, nil); err != nil {
+		return fmt.Errorf("env value for %s: %s", value.Summary(), err)
+	}
 	value.Help, err = interpolate(value.Help, vars, map[string]string{
 		"default": value.Default,
 		"enum":    value.Enum,
+		"env":     value.Flag.Env,
 	})
 	if err != nil {
 		return fmt.Errorf("help for %s: %s", value.Summary(), err)

--- a/kong_test.go
+++ b/kong_test.go
@@ -644,6 +644,7 @@ func TestInterpolationIntoModel(t *testing.T) {
 	var cli struct {
 		Flag    string `default:"${default}" help:"Help, I need ${somebody}" enum:"${enum}"`
 		EnumRef string `enum:"a,b" required:"" help:"One of ${enum}"`
+		EnvRef  string `env:"${env}" help:"God ${env}"`
 	}
 	_, err := kong.New(&cli)
 	require.Error(t, err)
@@ -651,14 +652,19 @@ func TestInterpolationIntoModel(t *testing.T) {
 		"default":  "Some default value.",
 		"somebody": "chickens!",
 		"enum":     "a,b,c,d",
+		"env":      "SAVE_THE_QUEEN",
 	})
 	require.NoError(t, err)
+	require.Len(t, p.Model.Flags, 4)
 	flag := p.Model.Flags[1]
 	flag2 := p.Model.Flags[2]
+	flag3 := p.Model.Flags[3]
 	require.Equal(t, "Some default value.", flag.Default)
 	require.Equal(t, "Help, I need chickens!", flag.Help)
 	require.Equal(t, map[string]bool{"a": true, "b": true, "c": true, "d": true}, flag.EnumMap())
 	require.Equal(t, "One of a,b", flag2.Help)
+	require.Equal(t, "SAVE_THE_QUEEN", flag3.Env)
+	require.Equal(t, "God SAVE_THE_QUEEN", flag3.Help)
 }
 
 func TestErrorMissingArgs(t *testing.T) {


### PR DESCRIPTION
Fixes issue #233 by enabling support for variable interpolation into the `env` struct tag.

```go
type cli struct {
	EnvFlag string `env:"${myEnv}" help:"Looks at ${myEnv}"`
}

ctx := kong.Parse(&cli{}, kong.Vars{
	"myEnv": "AN_ENV_VAR",
})
```