### PR TITLE
Fix env var interpolation

### DIFF
--- a/kong.go
+++ b/kong.go
@@ -201,6 +201,7 @@ func (k *Kong) interpolateValue(value *Value, vars Vars) (err error) {
 		if value.Flag.Env, err = interpolate(value.Flag.Env, vars, nil); err != nil {
 			return fmt.Errorf("env value for %s: %s", value.Summary(), err)
 		}
+		value.Tag.Env = value.Flag.Env
 		updatedVars["env"] = value.Flag.Env
 	}
 	value.Help, err = interpolate(value.Help, vars, updatedVars)

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -37,17 +37,26 @@ func TestEnvarsFlagBasic(t *testing.T) {
 	var cli struct {
 		String string `env:"KONG_STRING"`
 		Slice  []int  `env:"KONG_SLICE"`
+		Interp string `env:"${kongInterp}"`
 	}
-	parser, unsetEnvs := newEnvParser(t, &cli, envMap{
-		"KONG_STRING": "bye",
-		"KONG_SLICE":  "5,2,9",
-	})
+	kongInterpEnv := "KONG_INTERP"
+	parser, unsetEnvs := newEnvParser(t, &cli, 
+		envMap{
+			"KONG_STRING": "bye",
+			"KONG_SLICE":  "5,2,9",
+			"KONG_INTERP": "foo",
+		},
+		kong.Vars{
+			"kongInterp": kongInterpEnv,
+		},
+	)
 	defer unsetEnvs()
 
 	_, err := parser.Parse([]string{})
 	require.NoError(t, err)
 	require.Equal(t, "bye", cli.String)
 	require.Equal(t, []int{5, 2, 9}, cli.Slice)
+	require.Equal(t, "foo", cli.Interp)
 }
 
 func TestEnvarsFlagOverride(t *testing.T) {

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -40,7 +40,7 @@ func TestEnvarsFlagBasic(t *testing.T) {
 		Interp string `env:"${kongInterp}"`
 	}
 	kongInterpEnv := "KONG_INTERP"
-	parser, unsetEnvs := newEnvParser(t, &cli, 
+	parser, unsetEnvs := newEnvParser(t, &cli,
 		envMap{
 			"KONG_STRING": "bye",
 			"KONG_SLICE":  "5,2,9",


### PR DESCRIPTION
Support was added for variable interpolation of the `env` tag in #234, but it did not fully succeed in practice. This PR ensures that the `Env` attribute is updated on both the `value.Flag` and `value.Tag` of the node being interpolated.

Without this change, when `context.Reset` is called, the `env` value on the tag is still something like `${envToBeInterpolated}`, even though the the flag's `env` might be `SOME_ENV_VAR`.