### PR TITLE
Document nested data structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,21 @@ var CLI struct {
 
 For flags, multiple key+value pairs should be separated by `mapsep:"rune"` tag (defaults to `;`) eg. `--set="key1=value1;key2=value2"`.
 
+## Nested data structure
+
+Kong support a nested data structure as well with `embed:""`. You can combine `embed:""` with `prefix:""`:
+
+```go
+var CLI struct {
+  Logging struct {
+    Level string `enum:"debug,info,warn,error" default:"info"`
+    Type string `enum:"json,console" default:"console"`
+  } `embed:"" prefix:"logging."`
+}
+```
+
+This configures Kong to accept flags `--logging.level` and `--logging.type`.
+
 ## Custom named decoders
 
 Kong includes a number of builtin custom type mappers. These can be used by


### PR DESCRIPTION
See: https://github.com/alecthomas/kong/issues/256

I made this addition to documentation to make it clearer. I think it is a pretty common use case and it makes it nice to immediatelly see how Kong does it. Because when initially reading README I was like "nice, they use structs for sub-commands, but, hm, what if you just want a struct".