### PR TITLE
fix required/xor behavior w/ > 2 flags

### DIFF
--- a/context.go
+++ b/context.go
@@ -793,8 +793,8 @@ func checkMissingFlags(flags []*Flag) error {
 			missing = append(missing, flag.Summary())
 		}
 	}
-	for _, flags := range xorGroup {
-		if len(flags) > 1 {
+	for xor, flags := range xorGroup {
+		if !xorGroupSet[xor] && len(flags) > 1 {
 			missing = append(missing, strings.Join(flags, " or "))
 		}
 	}

--- a/kong_test.go
+++ b/kong_test.go
@@ -933,6 +933,10 @@ func TestXorRequiredMany(t *testing.T) {
 	require.NoError(t, err)
 
 	p = mustNew(t, &cli)
+	_, err = p.Parse([]string{"--three"})
+	require.NoError(t, err)
+
+	p = mustNew(t, &cli)
 	_, err = p.Parse([]string{})
 	require.EqualError(t, err, "missing flags: --one or --two or --three")
 }


### PR DESCRIPTION
Adds a check for if the xorGroupSet has been satisfied before building the list of missing flags.  Includes the test described in https://github.com/alecthomas/kong/issues/258.