### PR TITLE
Remove extraneous + in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,8 +556,8 @@ type Validatable interface {
  }
  ```
 
-+If one of these nodes is in the active command-line it will be called during
-+normal validation.
+If one of these nodes is in the active command-line it will be called during
+normal validation.
 
 ## Modifying Kong's behaviour
 


### PR DESCRIPTION
Removes + characters that were included from a previous diff.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

> Per usual, thanks for the time and effort put into this library!