### PR TITLE
Errors dictionary, moved hard code to constants, adding localization possibilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 bin
+
+# IDE
+.project
+.settings
+.idea

--- a/build.go
+++ b/build.go
@@ -15,7 +15,7 @@ func build(k *Kong, ast interface{}) (app *Application, err error) {
 	v := reflect.ValueOf(ast)
 	iv := reflect.Indirect(v)
 	if v.Kind() != reflect.Ptr || iv.Kind() != reflect.Struct {
-		return nil, fmt.Errorf("expected a pointer to a struct but got %T", ast)
+		return nil, Errors().ExpectedPointerToStructButGot(ast)
 	}
 
 	app = &Application{}
@@ -30,7 +30,7 @@ func build(k *Kong, ast interface{}) (app *Application, err error) {
 		return nil, err
 	}
 	if len(node.Positional) > 0 && len(node.Children) > 0 {
-		return nil, fmt.Errorf("can't mix positional arguments and branching arguments on %T", ast)
+		return nil, Errors().CantMixPositionalArgumentsBranchingArguments(ast)
 	}
 	app.Node = node
 	app.Node.Flags = append(extraFlags, app.Node.Flags...)

--- a/config_test.go
+++ b/config_test.go
@@ -48,8 +48,8 @@ func makeConfig(t *testing.T, config interface{}) (path string, cleanup func()) 
 	t.Helper()
 	w, err := ioutil.TempFile("", "")
 	require.NoError(t, err)
-	defer w.Close() // nolint: gosec
+	defer func() { _ = w.Close() }() // nolint: gosec
 	err = json.NewEncoder(w).Encode(config)
 	require.NoError(t, err)
-	return w.Name(), func() { os.Remove(w.Name()) }
+	return w.Name(), func() { _ = os.Remove(w.Name()) }
 }

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,61 @@
+// Package kong
+package kong
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckErrorOfMissingChildren(t *testing.T) {
+	var (
+		missing []string
+		err     error
+	)
+
+	defer func() {
+		if e := recover(); e != nil {
+			require.Equal(t, "fail=' error is not a type Err", e.(error).Error())
+		}
+	}()
+	// Not error
+	err = checkErrorOfMissingChildren(missing)
+	require.NoError(t, err)
+	// One
+	missing = append(missing, "1")
+	err = checkErrorOfMissingChildren(missing)
+	require.Error(t, err)
+	// Checking the error object, a Errors().Expected error should be returned
+	if err.(Err).Anchor() != Errors().Expected("").Anchor() {
+		t.Fatalf("Incorrect error object, expected Errors().Expected")
+	}
+	if err.(Err).Anchor() == Errors().ExpectedOneOf("").Anchor() {
+		t.Fatalf("Incorrect error object, expected Errors().Expected")
+	}
+	// Less or equal five elements
+	missing = append(missing, "2", "3", "4", "5")
+	err = checkErrorOfMissingChildren(missing)
+	require.Error(t, err)
+	// Checking the error object, a Errors().ExpectedOneOf error should be returned
+	if err.(Err).Anchor() != Errors().ExpectedOneOf("").Anchor() {
+		t.Fatalf("Incorrect error object, expected Errors().ExpectedOneOf")
+	}
+	if err.(Err).Anchor() == Errors().Expected("").Anchor() {
+		t.Fatalf("Incorrect error object, expected Errors().ExpectedOneOf")
+	}
+	// Check not present constant onyOther
+	require.NotContains(t, err.Error(), onyOther)
+	// More five elements
+	missing = append(missing, "6")
+	err = checkErrorOfMissingChildren(missing)
+	require.Error(t, err)
+	// And specified error
+	if err.(Err).Anchor() != Errors().ExpectedOneOf("").Anchor() {
+		t.Fatalf("Incorrect error object, expected Errors().ExpectedOneOf")
+	}
+	if err.(Err).Anchor() == Errors().Expected("").Anchor() {
+		t.Fatalf("Incorrect error object, expected Errors().ExpectedOneOf")
+	}
+	// Check constant onyOther
+	require.Contains(t, err.Error(), onyOther)
+}

--- a/cotstants.go
+++ b/cotstants.go
@@ -1,0 +1,40 @@
+// Package kong
+package kong
+
+const (
+	anonymousStruct         = `<anonymous struct>`
+	interpolateValueDefault = `default`
+	interpolateValueEnum    = `enum`
+	panicUnsupportedPath    = `unsupported Path`
+	keyBeforeResolve        = `BeforeResolve`
+	keyBeforeApply          = `BeforeApply`
+	keyAfterApply           = `AfterApply`
+	keyVersion              = `version`
+	keyEnv                  = `env`
+	keyValue                = `value`
+	keyString               = `string`
+	onyOther                = `...`
+	delimiterComma          = `,`
+	delimiterCommaSpace     = `, `
+	delimiterPoint          = `.`
+	delimiterDash           = `-`
+	delimiterDoubleDash     = `--`
+	delimiterUnderscore     = `_`
+	delimiterSpace          = ` `
+	delimiterDollar         = `$`
+	cmdWithArgs             = `withargs`
+
+	// help constants
+	helpName             = `help`
+	helpHelp             = `Show context-sensitive help.`
+	helpOrigin           = `Show context-sensitive help.`
+	helpShort            = 'h'
+	helpDefaultValue     = false
+	defaultIndent        = 2
+	defaultColumnPadding = 4
+)
+
+const (
+	shortUsage usageOnError = iota + 1
+	fullUsage
+)

--- a/cotstants.go
+++ b/cotstants.go
@@ -23,6 +23,7 @@ const (
 	delimiterSpace          = ` `
 	delimiterDollar         = `$`
 	cmdWithArgs             = `withargs`
+	keyError                = `error`
 
 	// help constants
 	helpName             = `help`
@@ -32,6 +33,9 @@ const (
 	helpDefaultValue     = false
 	defaultIndent        = 2
 	defaultColumnPadding = 4
+	labelCommands        = `Commands:`
+	labelFlags           = `Flags:`
+	labelArguments       = `Arguments:`
 )
 
 const (

--- a/defaults.go
+++ b/defaults.go
@@ -1,21 +1,25 @@
 package kong
 
 // ApplyDefaults if they are not already set.
-func ApplyDefaults(target interface{}, options ...Option) error {
-	app, err := New(target, options...)
-	if err != nil {
-		return err
+func ApplyDefaults(target interface{}, options ...Option) (err error) {
+	var (
+		app *Kong
+		ctx *Context
+	)
+
+	if app, err = New(target, options...); err != nil {
+		return
 	}
-	ctx, err := Trace(app, nil)
-	if err != nil {
-		return err
+	if ctx, err = Trace(app, nil); err != nil {
+		return
 	}
-	err = ctx.Resolve()
-	if err != nil {
-		return err
+	if err = ctx.Resolve(); err != nil {
+		return
 	}
 	if err = ctx.ApplyDefaults(); err != nil {
-		return err
+		return
 	}
-	return ctx.Validate()
+	err = ctx.Validate()
+
+	return
 }

--- a/error.go
+++ b/error.go
@@ -10,3 +10,17 @@ type ParseError struct {
 
 // Unwrap returns the original cause of the error.
 func (p *ParseError) Unwrap() error { return p.error }
+
+// IsErrInterfaceImplements returns the original cause of the error if type is implements Err interface.
+func (p *ParseError) IsErrInterfaceImplements() (err Err, ok bool) { err, ok = p.error.(Err); return }
+
+// MustErr returns the original cause of the error type Err interface anyway
+func (p *ParseError) MustErr() (err Err) {
+	var ok bool
+
+	if err, ok = p.IsErrInterfaceImplements(); !ok {
+		err = Errors().UnknownError(p.Unwrap())
+	}
+
+	return
+}

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,150 @@
+// Package kong
+package kong
+
+import "strings"
+
+const (
+	cUnknownError                          = "unknown error: %s"
+	cNoCommandSelected                     = "no command selected"
+	cExpected                              = "expected %s"
+	cExpectedOneOf                         = "expected one of %s"
+	cUnexpectedArgument                    = "unexpected argument %s"
+	cUnexpectedFlagArgument                = "unexpected flag argument %q"
+	cUnexpectedToken                       = "unexpected token %s"
+	cUnknownFlag                           = "unknown flag %s"
+	cMissingFlags                          = "missing flags: %s"
+	cHelperErrorDidYouMean                 = "%s, did you mean %s?"
+	cHelperErrorDidYouMeanOneOf            = "%s, did you mean one of %s?"
+	cDefaultValueFor                       = "default value for %s: %s"
+	cEnumValueFor                          = "enum value for %s: %s"
+	cEnvValueFor                           = "env value for %s: %s"
+	cHelpFor                               = "help for %s: %s"
+	cIsRequired                            = "%s is required"
+	cEnumSliceOrValue                      = "enum can only be applied to a slice or value"
+	cMustBeOneOfButGot                     = "%s must be one of %s but got %q"
+	cMissingPositionalArguments            = "missing positional arguments %s"
+	cFailField                             = "%s.%s: %s"
+	cRegexInputCannotBeEmpty               = "regex input cannot be empty"
+	cRegexUnableToCompile                  = "unable to compile regex: %s"
+	cKongMustBeConfiguredWithConfiguration = "kong must be configured with kong.Configuration"
+	cUndefinedVariable                     = "undefined variable ${%s}"
+)
+
+var (
+	errSingleton                             = &Error{}
+	errUnknownError                          = err{tpl: cUnknownError}
+	errNoCommandSelected                     = err{tpl: cNoCommandSelected}
+	errExpected                              = err{tpl: cExpected}
+	errExpectedOneOf                         = err{tpl: cExpectedOneOf}
+	errUnexpectedArgument                    = err{tpl: cUnexpectedArgument}
+	errUnexpectedFlagArgument                = err{tpl: cUnexpectedFlagArgument}
+	errUnexpectedToken                       = err{tpl: cUnexpectedToken}
+	errUnknownFlag                           = err{tpl: cUnknownFlag}
+	errMissingFlags                          = err{tpl: cMissingFlags}
+	errHelperErrorDidYouMean                 = err{tpl: cHelperErrorDidYouMean}
+	errHelperErrorDidYouMeanOneOf            = err{tpl: cHelperErrorDidYouMeanOneOf}
+	errDefaultValueFor                       = err{tpl: cDefaultValueFor}
+	errEnumValueFor                          = err{tpl: cEnumValueFor}
+	errEnvValueFor                           = err{tpl: cEnvValueFor}
+	errHelpFor                               = err{tpl: cHelpFor}
+	errIsRequired                            = err{tpl: cIsRequired}
+	errEnumSliceOrValue                      = err{tpl: cEnumSliceOrValue}
+	errMustBeOneOfButGot                     = err{tpl: cMustBeOneOfButGot}
+	errMissingPositionalArguments            = err{tpl: cMissingPositionalArguments}
+	errFailField                             = err{tpl: cFailField}
+	errRegexInputCannotBeEmpty               = err{tpl: cRegexInputCannotBeEmpty}
+	errRegexUnableToCompile                  = err{tpl: cRegexUnableToCompile}
+	errKongMustBeConfiguredWithConfiguration = err{tpl: cKongMustBeConfiguredWithConfiguration}
+	errUndefinedVariable                     = err{tpl: cUndefinedVariable}
+)
+
+// ERRORS: Implementation of errors with the ability to compare errors with each other
+
+// UnknownError Unknown Error
+func (e *Error) UnknownError(err error) Err { return newErr(&errUnknownError, err) }
+
+// NoCommandSelected no command selected
+func (e *Error) NoCommandSelected() Err { return newErr(&errNoCommandSelected) }
+
+// Expected children ...
+func (e *Error) Expected(s string) Err { return newErr(&errExpected, s) }
+
+// ExpectedOneOf Expected one of ...
+func (e *Error) ExpectedOneOf(s string) Err { return newErr(&errExpectedOneOf, s) }
+
+// UnexpectedArgument Unexpected argument ...
+func (e *Error) UnexpectedArgument(argument string) Err {
+	return newErr(&errUnexpectedArgument, argument)
+}
+
+// UnexpectedFlagArgument unexpected flag argument
+func (e *Error) UnexpectedFlagArgument(argument interface{}) Err {
+	return newErr(&errUnexpectedFlagArgument, argument)
+}
+
+// UnexpectedToken Unexpected token ...
+func (e *Error) UnexpectedToken(token Token) Err { return newErr(&errUnexpectedToken, token) }
+
+// UnknownFlag unknown flag ...
+func (e *Error) UnknownFlag(flag string) Err { return newErr(&errUnknownFlag, flag) }
+
+// MissingFlags missing flags: ...
+func (e *Error) MissingFlags(flag string) Err { return newErr(&errMissingFlags, flag) }
+
+// HelperErrorDidYouMean ..., did you mean ...?
+func (e *Error) HelperErrorDidYouMean(err error, hypothesis string) Err {
+	return newErr(&errHelperErrorDidYouMean, err, hypothesis)
+}
+
+// HelperErrorDidYouMeanOneOf ..., did you mean one of ...?
+func (e *Error) HelperErrorDidYouMeanOneOf(err error, hypothesis []string) Err {
+	const hypothesisDelimiter = `, `
+	return newErr(&errHelperErrorDidYouMeanOneOf, err, strings.Join(hypothesis, hypothesisDelimiter))
+}
+
+// DefaultValueFor default value for ...
+func (e *Error) DefaultValueFor(s string, err error) Err { return newErr(&errDefaultValueFor, s, err) }
+
+// EnumValueFor enum value for ...
+func (e *Error) EnumValueFor(s string, err error) Err { return newErr(&errEnumValueFor, s, err) }
+
+// EnvValueFor env value for ...
+func (e *Error) EnvValueFor(s string, err error) Err { return newErr(&errEnvValueFor, s, err) }
+
+// HelpFor help for ...
+func (e *Error) HelpFor(s string, err error) Err { return newErr(&errHelpFor, s, err) }
+
+// IsRequired ... is required
+func (e *Error) IsRequired(required string) Err { return newErr(&errIsRequired, required) }
+
+// EnumSliceOrValue Enum can only be applied to a slice or value
+func (e *Error) EnumSliceOrValue() Err { return newErr(&errEnumSliceOrValue) }
+
+// MustBeOneOfButGot ... must be one of ... but got ...
+func (e *Error) MustBeOneOfButGot(summary string, enums string, item interface{}) Err {
+	return newErr(&errMustBeOneOfButGot, summary, enums, item)
+}
+
+// MissingPositionalArguments missing positional arguments ...
+func (e *Error) MissingPositionalArguments(arguments string) Err {
+	return newErr(&errMissingPositionalArguments, arguments)
+}
+
+// FailField Error for check field
+func (e *Error) FailField(parent, name, value string) Err {
+	return newErr(&errFailField, parent, name, value)
+}
+
+// RegexInputCannotBeEmpty Regex input cannot be empty
+func (e *Error) RegexInputCannotBeEmpty() Err { return newErr(&errRegexInputCannotBeEmpty) }
+
+// RegexUnableToCompile Unable to compile regex: ...
+func (e *Error) RegexUnableToCompile(err error) Err { return newErr(&errRegexUnableToCompile, err) }
+
+// KongMustBeConfiguredWithConfiguration Kong must be configured with kong.Configuration
+func (e *Error) KongMustBeConfiguredWithConfiguration() Err {
+	return newErr(&errKongMustBeConfiguredWithConfiguration)
+}
+
+// UndefinedVariable undefined variable ...
+func (e *Error) UndefinedVariable(name string) Err { return newErr(&errUndefinedVariable, name) }

--- a/errors.go
+++ b/errors.go
@@ -4,58 +4,62 @@ package kong
 import "strings"
 
 const (
-	cUnknownError                          = "unknown error: %s"
-	cNoCommandSelected                     = "no command selected"
-	cExpected                              = "expected %s"
-	cExpectedOneOf                         = "expected one of %s"
-	cUnexpectedArgument                    = "unexpected argument %s"
-	cUnexpectedFlagArgument                = "unexpected flag argument %q"
-	cUnexpectedToken                       = "unexpected token %s"
-	cUnknownFlag                           = "unknown flag %s"
-	cMissingFlags                          = "missing flags: %s"
-	cHelperErrorDidYouMean                 = "%s, did you mean %s?"
-	cHelperErrorDidYouMeanOneOf            = "%s, did you mean one of %s?"
-	cDefaultValueFor                       = "default value for %s: %s"
-	cEnumValueFor                          = "enum value for %s: %s"
-	cEnvValueFor                           = "env value for %s: %s"
-	cHelpFor                               = "help for %s: %s"
-	cIsRequired                            = "%s is required"
-	cEnumSliceOrValue                      = "enum can only be applied to a slice or value"
-	cMustBeOneOfButGot                     = "%s must be one of %s but got %q"
-	cMissingPositionalArguments            = "missing positional arguments %s"
-	cFailField                             = "%s.%s: %s"
-	cRegexInputCannotBeEmpty               = "regex input cannot be empty"
-	cRegexUnableToCompile                  = "unable to compile regex: %s"
-	cKongMustBeConfiguredWithConfiguration = "kong must be configured with kong.Configuration"
-	cUndefinedVariable                     = "undefined variable ${%s}"
+	cUnknownError                                 = "unknown error: %s"
+	cNoCommandSelected                            = "no command selected"
+	cExpected                                     = "expected %s"
+	cExpectedOneOf                                = "expected one of %s"
+	cUnexpectedArgument                           = "unexpected argument %s"
+	cUnexpectedFlagArgument                       = "unexpected flag argument %q"
+	cUnexpectedToken                              = "unexpected token %s"
+	cUnknownFlag                                  = "unknown flag %s"
+	cMissingFlags                                 = "missing flags: %s"
+	cHelperErrorDidYouMean                        = "%s, did you mean %s?"
+	cHelperErrorDidYouMeanOneOf                   = "%s, did you mean one of %s?"
+	cDefaultValueFor                              = "default value for %s: %s"
+	cEnumValueFor                                 = "enum value for %s: %s"
+	cEnvValueFor                                  = "env value for %s: %s"
+	cHelpFor                                      = "help for %s: %s"
+	cIsRequired                                   = "%s is required"
+	cEnumSliceOrValue                             = "enum can only be applied to a slice or value"
+	cMustBeOneOfButGot                            = "%s must be one of %s but got %q"
+	cMissingPositionalArguments                   = "missing positional arguments %s"
+	cFailField                                    = "%s.%s: %s"
+	cRegexInputCannotBeEmpty                      = "regex input cannot be empty"
+	cRegexUnableToCompile                         = "unable to compile regex: %s"
+	cKongMustBeConfiguredWithConfiguration        = "kong must be configured with kong.Configuration"
+	cUndefinedVariable                            = "undefined variable ${%s}"
+	cExpectedPointerToStructButGot                = "expected a pointer to a struct but got %T"
+	cCantMixPositionalArgumentsBranchingArguments = "can't mix positional arguments and branching arguments on %T"
 )
 
 var (
-	errSingleton                             = &Error{}
-	errUnknownError                          = err{tpl: cUnknownError}
-	errNoCommandSelected                     = err{tpl: cNoCommandSelected}
-	errExpected                              = err{tpl: cExpected}
-	errExpectedOneOf                         = err{tpl: cExpectedOneOf}
-	errUnexpectedArgument                    = err{tpl: cUnexpectedArgument}
-	errUnexpectedFlagArgument                = err{tpl: cUnexpectedFlagArgument}
-	errUnexpectedToken                       = err{tpl: cUnexpectedToken}
-	errUnknownFlag                           = err{tpl: cUnknownFlag}
-	errMissingFlags                          = err{tpl: cMissingFlags}
-	errHelperErrorDidYouMean                 = err{tpl: cHelperErrorDidYouMean}
-	errHelperErrorDidYouMeanOneOf            = err{tpl: cHelperErrorDidYouMeanOneOf}
-	errDefaultValueFor                       = err{tpl: cDefaultValueFor}
-	errEnumValueFor                          = err{tpl: cEnumValueFor}
-	errEnvValueFor                           = err{tpl: cEnvValueFor}
-	errHelpFor                               = err{tpl: cHelpFor}
-	errIsRequired                            = err{tpl: cIsRequired}
-	errEnumSliceOrValue                      = err{tpl: cEnumSliceOrValue}
-	errMustBeOneOfButGot                     = err{tpl: cMustBeOneOfButGot}
-	errMissingPositionalArguments            = err{tpl: cMissingPositionalArguments}
-	errFailField                             = err{tpl: cFailField}
-	errRegexInputCannotBeEmpty               = err{tpl: cRegexInputCannotBeEmpty}
-	errRegexUnableToCompile                  = err{tpl: cRegexUnableToCompile}
-	errKongMustBeConfiguredWithConfiguration = err{tpl: cKongMustBeConfiguredWithConfiguration}
-	errUndefinedVariable                     = err{tpl: cUndefinedVariable}
+	errSingleton                                    = &Error{}
+	errUnknownError                                 = err{tpl: cUnknownError}
+	errNoCommandSelected                            = err{tpl: cNoCommandSelected}
+	errExpected                                     = err{tpl: cExpected}
+	errExpectedOneOf                                = err{tpl: cExpectedOneOf}
+	errUnexpectedArgument                           = err{tpl: cUnexpectedArgument}
+	errUnexpectedFlagArgument                       = err{tpl: cUnexpectedFlagArgument}
+	errUnexpectedToken                              = err{tpl: cUnexpectedToken}
+	errUnknownFlag                                  = err{tpl: cUnknownFlag}
+	errMissingFlags                                 = err{tpl: cMissingFlags}
+	errHelperErrorDidYouMean                        = err{tpl: cHelperErrorDidYouMean}
+	errHelperErrorDidYouMeanOneOf                   = err{tpl: cHelperErrorDidYouMeanOneOf}
+	errDefaultValueFor                              = err{tpl: cDefaultValueFor}
+	errEnumValueFor                                 = err{tpl: cEnumValueFor}
+	errEnvValueFor                                  = err{tpl: cEnvValueFor}
+	errHelpFor                                      = err{tpl: cHelpFor}
+	errIsRequired                                   = err{tpl: cIsRequired}
+	errEnumSliceOrValue                             = err{tpl: cEnumSliceOrValue}
+	errMustBeOneOfButGot                            = err{tpl: cMustBeOneOfButGot}
+	errMissingPositionalArguments                   = err{tpl: cMissingPositionalArguments}
+	errFailField                                    = err{tpl: cFailField}
+	errRegexInputCannotBeEmpty                      = err{tpl: cRegexInputCannotBeEmpty}
+	errRegexUnableToCompile                         = err{tpl: cRegexUnableToCompile}
+	errKongMustBeConfiguredWithConfiguration        = err{tpl: cKongMustBeConfiguredWithConfiguration}
+	errUndefinedVariable                            = err{tpl: cUndefinedVariable}
+	errExpectedPointerToStructButGot                = err{tpl: cExpectedPointerToStructButGot}
+	errCantMixPositionalArgumentsBranchingArguments = err{tpl: cCantMixPositionalArgumentsBranchingArguments}
 )
 
 // ERRORS: Implementation of errors with the ability to compare errors with each other
@@ -148,3 +152,13 @@ func (e *Error) KongMustBeConfiguredWithConfiguration() Err {
 
 // UndefinedVariable undefined variable ...
 func (e *Error) UndefinedVariable(name string) Err { return newErr(&errUndefinedVariable, name) }
+
+// ExpectedPointerToStructButGot expected a pointer to a struct but got ...
+func (e *Error) ExpectedPointerToStructButGot(ast interface{}) Err {
+	return newErr(&errExpectedPointerToStructButGot, ast)
+}
+
+// CantMixPositionalArgumentsBranchingArguments Can't mix positional arguments and branching arguments on ...
+func (e *Error) CantMixPositionalArgumentsBranchingArguments(ast interface{}) Err {
+	return newErr(&errCantMixPositionalArgumentsBranchingArguments, ast)
+}

--- a/errors_types.go
+++ b/errors_types.go
@@ -1,0 +1,45 @@
+// Package kong
+package kong
+
+import "fmt"
+
+type (
+	// Error A singleton object with a list of errors that can be compared by anchor through ==
+	Error struct{}
+
+	// The internal structure of the error object with arguments, template, anchor and error interface
+	err struct {
+		tpl    string        // Template of error
+		args   []interface{} // Other error arguments
+		anchor error         // Fixed address constant of error
+		errFn  func() string // Function of interface error
+	}
+
+	// Err an Error interface
+	Err interface {
+		Anchor() error       // Anchor by which you can compare two errors with each other
+		Error() string       // Error message or error message template
+		Args() []interface{} // Original arguments for error template
+	}
+)
+
+// Anchor Implementation of interface Err
+func (err err) Anchor() error { return err.anchor }
+
+// Error Implementation of interface Err
+func (err err) Error() string { return err.errFn() }
+
+// Args Implementation of interface Err
+func (err err) Args() []interface{} { return err.args }
+
+// Errors Collection of package errors that can be compared with each other
+func Errors() *Error { return errSingleton }
+
+// Object constructor
+func newErr(obj *err, arg ...interface{}) Err {
+	return &err{
+		anchor: obj,
+		args:   arg,
+		errFn:  func() string { return fmt.Sprintf(obj.tpl, arg...) },
+	}
+}

--- a/global.go
+++ b/global.go
@@ -1,8 +1,6 @@
 package kong
 
-import (
-	"os"
-)
+import "os"
 
 // Parse constructs a new parser and parses the default command-line.
 func Parse(cli interface{}, options ...Option) *Context {

--- a/help.go
+++ b/help.go
@@ -8,11 +8,6 @@ import (
 	"strings"
 )
 
-const (
-	defaultIndent        = 2
-	defaultColumnPadding = 4
-)
-
 // Help flag.
 type helpValue bool
 
@@ -91,12 +86,12 @@ func DefaultHelpValueFormatter(value *Value) string {
 	}
 	suffix := "($" + value.Tag.Env + ")"
 	switch {
-	case strings.HasSuffix(value.Help, "."):
-		return value.Help[:len(value.Help)-1] + " " + suffix + "."
+	case strings.HasSuffix(value.Help, delimiterPoint):
+		return value.Help[:len(value.Help)-1] + delimiterSpace + suffix + delimiterPoint
 	case value.Help == "":
 		return suffix
 	default:
-		return value.Help + " " + suffix
+		return value.Help + delimiterSpace + suffix
 	}
 }
 
@@ -391,7 +386,7 @@ func (h *helpWriter) Printf(format string, args ...interface{}) {
 }
 
 func (h *helpWriter) Print(text string) {
-	*h.lines = append(*h.lines, strings.TrimRight(h.indent+text, " "))
+	*h.lines = append(*h.lines, strings.TrimRight(h.indent+text, delimiterSpace))
 }
 
 // Indent returns a new helpWriter indented by two characters.
@@ -466,11 +461,11 @@ func writeTwoColumns(w *helpWriter, rows [][2]string) {
 		}
 	}
 
-	offsetStr := strings.Repeat(" ", leftSize+defaultColumnPadding)
+	offsetStr := strings.Repeat(delimiterSpace, leftSize+defaultColumnPadding)
 
 	for _, row := range rows {
 		buf := bytes.NewBuffer(nil)
-		doc.ToText(buf, row[1], "", strings.Repeat(" ", defaultIndent), w.width-leftSize-defaultColumnPadding)
+		doc.ToText(buf, row[1], "", strings.Repeat(delimiterSpace, defaultIndent), w.width-leftSize-defaultColumnPadding)
 		lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
 
 		line := fmt.Sprintf("%-*s", leftSize, row[0])
@@ -524,7 +519,7 @@ func (h *HelpOptions) CommandTree(node *Node, prefix string) (rows [][2]string) 
 	default:
 		nodeName += prefix + node.Name
 		if len(node.Aliases) != 0 {
-			nodeName += fmt.Sprintf(" (%s)", strings.Join(node.Aliases, ","))
+			nodeName += fmt.Sprintf(" (%s)", strings.Join(node.Aliases, delimiterComma))
 		}
 	case ArgumentNode:
 		nodeName += prefix + "<" + node.Name + ">"
@@ -549,7 +544,7 @@ func (h *HelpOptions) CommandTree(node *Node, prefix string) (rows [][2]string) 
 
 // SpaceIndenter adds a space indent to the given prefix.
 func SpaceIndenter(prefix string) string {
-	return prefix + strings.Repeat(" ", defaultIndent)
+	return prefix + strings.Repeat(delimiterSpace, defaultIndent)
 }
 
 // LineIndenter adds line points to every new indent.
@@ -557,7 +552,7 @@ func LineIndenter(prefix string) string {
 	if prefix == "" {
 		return "- "
 	}
-	return strings.Repeat(" ", defaultIndent) + prefix
+	return strings.Repeat(delimiterSpace, defaultIndent) + prefix
 }
 
 // TreeIndenter adds line points to every new indent and vertical lines to every layer.
@@ -565,5 +560,5 @@ func TreeIndenter(prefix string) string {
 	if prefix == "" {
 		return "|- "
 	}
-	return "|" + strings.Repeat(" ", defaultIndent) + prefix
+	return "|" + strings.Repeat(delimiterSpace, defaultIndent) + prefix
 }

--- a/hooks.go
+++ b/hooks.go
@@ -2,18 +2,18 @@ package kong
 
 // BeforeResolve is a documentation-only interface describing hooks that run before resolvers are applied.
 type BeforeResolve interface {
-	// This is not the correct signature - see README for details.
+	// BeforeResolve This is not the correct signature - see README for details.
 	BeforeResolve(args ...interface{}) error
 }
 
 // BeforeApply is a documentation-only interface describing hooks that run before values are set.
 type BeforeApply interface {
-	// This is not the correct signature - see README for details.
+	// BeforeApply This is not the correct signature - see README for details.
 	BeforeApply(args ...interface{}) error
 }
 
 // AfterApply is a documentation-only interface describing hooks that run after values are set.
 type AfterApply interface {
-	// This is not the correct signature - see README for details.
+	// AfterApply This is not the correct signature - see README for details.
 	AfterApply(args ...interface{}) error
 }

--- a/kong_test.go
+++ b/kong_test.go
@@ -1290,7 +1290,7 @@ func TestDynamicCommands(t *testing.T) {
 	require.True(t, two.ran)
 
 	_, err = p.Parse([]string{"--help"})
-	require.EqualError(t, err, `expected one of "one",  "two"`)
+	require.EqualError(t, err, `expected one of "one", "two"`)
 	require.NotContains(t, help.String(), "three", help.String())
 }
 

--- a/mapper.go
+++ b/mapper.go
@@ -66,7 +66,7 @@ type textUnmarshalerAdapter struct{}
 
 func (m *textUnmarshalerAdapter) Decode(ctx *DecodeContext, target reflect.Value) error {
 	var value string
-	err := ctx.Scan.PopValueInto("value", &value)
+	err := ctx.Scan.PopValueInto(keyValue, &value)
 	if err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ type binaryUnmarshalerAdapter struct{}
 
 func (m *binaryUnmarshalerAdapter) Decode(ctx *DecodeContext, target reflect.Value) error {
 	var value string
-	err := ctx.Scan.PopValueInto("value", &value)
+	err := ctx.Scan.PopValueInto(keyValue, &value)
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ type jsonUnmarshalerAdapter struct{}
 
 func (j *jsonUnmarshalerAdapter) Decode(ctx *DecodeContext, target reflect.Value) error {
 	var value string
-	err := ctx.Scan.PopValueInto("value", &value)
+	err := ctx.Scan.PopValueInto(keyValue, &value)
 	if err != nil {
 		return err
 	}
@@ -567,7 +567,7 @@ func pathMapper(r *Registry) MapperFunc {
 		if err != nil {
 			return err
 		}
-		if path != "-" {
+		if path != delimiterDash {
 			path = ExpandPath(path)
 		}
 		target.SetString(path)
@@ -586,7 +586,7 @@ func fileMapper(r *Registry) MapperFunc {
 			return err
 		}
 		var file *os.File
-		if path == "-" {
+		if path == delimiterDash {
 			file = os.Stdin
 		} else {
 			path = ExpandPath(path)
@@ -613,7 +613,7 @@ func existingFileMapper(r *Registry) MapperFunc {
 		if err != nil {
 			return err
 		}
-		if path != "-" {
+		if path != delimiterDash {
 			path = ExpandPath(path)
 			stat, err := os.Stat(path)
 			if err != nil {

--- a/model.go
+++ b/model.go
@@ -143,7 +143,7 @@ func (n *Node) Depth() int {
 func (n *Node) Summary() string {
 	summary := n.Path()
 	if flags := n.FlagSummary(true); flags != "" {
-		summary += " " + flags
+		summary += delimiterSpace + flags
 	}
 	args := []string{}
 	optional := 0
@@ -156,7 +156,7 @@ func (n *Node) Summary() string {
 		args = append(args, argSummary)
 	}
 	if len(args) != 0 {
-		summary += " " + strings.Join(args, " ") + strings.Repeat("]", optional)
+		summary += delimiterSpace + strings.Join(args, delimiterSpace) + strings.Repeat("]", optional)
 	} else if len(n.Children) > 0 {
 		summary += " <command>"
 	}
@@ -175,7 +175,7 @@ func (n *Node) FlagSummary(hide bool) string {
 			}
 		}
 	}
-	return strings.Join(required, " ")
+	return strings.Join(required, delimiterSpace)
 }
 
 // FullPath is like Path() but includes the Application root node.
@@ -184,7 +184,7 @@ func (n *Node) FullPath() string {
 	for root.Parent != nil {
 		root = root.Parent
 	}
-	return strings.TrimSpace(root.Name + " " + n.Path())
+	return strings.TrimSpace(root.Name + delimiterSpace + n.Path())
 }
 
 // Vars returns the combined Vars defined by all ancestors of this Node.
@@ -198,16 +198,16 @@ func (n *Node) Vars() Vars {
 // Path through ancestors to this Node.
 func (n *Node) Path() (out string) {
 	if n.Parent != nil {
-		out += " " + n.Parent.Path()
+		out += delimiterSpace + n.Parent.Path()
 	}
 	switch n.Type {
 	case CommandNode:
-		out += " " + n.Name
+		out += delimiterSpace + n.Name
 		if len(n.Aliases) > 0 {
-			out += fmt.Sprintf(" (%s)", strings.Join(n.Aliases, ","))
+			out += fmt.Sprintf(" (%s)", strings.Join(n.Aliases, delimiterComma))
 		}
 	case ArgumentNode:
-		out += " " + "<" + n.Name + ">"
+		out += delimiterSpace + "<" + n.Name + ">"
 	default:
 	}
 	return strings.TrimSpace(out)
@@ -247,7 +247,7 @@ type Value struct {
 
 // EnumMap returns a map of the enums in this value.
 func (v *Value) EnumMap() map[string]bool {
-	parts := strings.Split(v.Enum, ",")
+	parts := strings.Split(v.Enum, delimiterComma)
 	out := make(map[string]bool, len(parts))
 	for _, part := range parts {
 		out[strings.TrimSpace(part)] = true
@@ -257,7 +257,7 @@ func (v *Value) EnumMap() map[string]bool {
 
 // EnumSlice returns a slice of the enums in this value.
 func (v *Value) EnumSlice() []string {
-	parts := strings.Split(v.Enum, ",")
+	parts := strings.Split(v.Enum, delimiterComma)
 	out := make([]string, len(parts))
 	for i, part := range parts {
 		out[i] = strings.TrimSpace(part)
@@ -394,7 +394,7 @@ type Flag struct {
 }
 
 func (f *Flag) String() string {
-	out := "--" + f.Name
+	out := delimiterDoubleDash + f.Name
 	if f.Short != 0 {
 		out = fmt.Sprintf("-%c, %s", f.Short, out)
 	}

--- a/options.go
+++ b/options.go
@@ -393,7 +393,6 @@ func Configuration(loader ConfigurationLoader, paths ...string) Option {
 }
 
 // ExpandPath is a helper function to expand a relative or home-relative path to an absolute path.
-//
 // eg. ~/.someconf -> /home/alec/.someconf
 func ExpandPath(path string) string {
 	if filepath.IsAbs(path) {
@@ -480,6 +479,57 @@ func HelpDisplaySetup(
 		k.helpFlag.Value.OrigHelp = valueOrDefaultValue(origin, helpOrigin).(string)
 		k.helpFlag.Short = valueOrDefaultValue(short, helpShort).(int32)
 		k.helpFlag.Value.DefaultValue = reflect.ValueOf(valueOrDefaultValue(defaultValue, helpDefaultValue).(bool))
+		return
+	})
+}
+
+func HelpCommandsLabelSetup(labelCommands string) Option {
+	return PostBuild(func(k *Kong) (err error) {
+		k.labelCommands = labelCommands
+		return
+	})
+}
+
+func HelpFlagsLabelSetup(labelFlags string) Option {
+	return PostBuild(func(k *Kong) (err error) {
+		k.labelFlags = labelFlags
+		return
+	})
+}
+
+func HelpArgumentsLabelSetup(labelArguments string) Option {
+	return PostBuild(func(k *Kong) (err error) {
+		k.labelArguments = labelArguments
+		return
+	})
+}
+
+// UsageHelperFunc Assigning a usage print function via a custom template
+func UsageHelperFunc(usageHelperFn UsageHelperFn) Option {
+	return PostBuild(func(k *Kong) (err error) {
+		if usageHelperFn != nil {
+			k.usageHelper = usageHelperFn
+		}
+		return
+	})
+}
+
+// RunArgumentHelperFunc Assigning a usage run print function via a custom template
+func RunArgumentHelperFunc(runArgumentHelperFn RunArgumentHelperFn) Option {
+	return PostBuild(func(k *Kong) (err error) {
+		if runArgumentHelperFn != nil {
+			k.runArgumentHelper = runArgumentHelperFn
+		}
+		return
+	})
+}
+
+// RunCommandArgumentHelperFunc Assigning a usage print function via a custom template
+func RunCommandArgumentHelperFunc(runCommandArgumentHelperFn RunCommandArgumentHelperFn) Option {
+	return PostBuild(func(k *Kong) (err error) {
+		if runCommandArgumentHelperFn != nil {
+			k.runCommandArgumentHelper = runCommandArgumentHelperFn
+		}
 		return
 	})
 }

--- a/resolver.go
+++ b/resolver.go
@@ -37,13 +37,13 @@ func JSON(r io.Reader) (Resolver, error) {
 		return nil, err
 	}
 	var f ResolverFunc = func(context *Context, parent *Path, flag *Flag) (interface{}, error) {
-		name := strings.ReplaceAll(flag.Name, "-", "_")
+		name := strings.ReplaceAll(flag.Name, delimiterDash, delimiterUnderscore)
 		raw, ok := values[name]
 		if ok {
 			return raw, nil
 		}
 		raw = values
-		for _, part := range strings.Split(name, ".") {
+		for _, part := range strings.Split(name, delimiterPoint) {
 			if values, ok := raw.(map[string]interface{}); ok {
 				raw, ok = values[part]
 				if !ok {

--- a/scanner.go
+++ b/scanner.go
@@ -82,11 +82,11 @@ func (t Token) InferredType() TokenType {
 		return t.Type
 	}
 	if v, ok := t.Value.(string); ok {
-		if strings.HasPrefix(v, "--") { // nolint: gocritic
+		if strings.HasPrefix(v, delimiterDoubleDash) { // nolint: gocritic
 			return FlagToken
-		} else if v == "-" {
+		} else if v == delimiterDash {
 			return PositionalArgumentToken
-		} else if strings.HasPrefix(v, "-") {
+		} else if strings.HasPrefix(v, delimiterDash) {
 			return ShortFlagToken
 		}
 	}
@@ -99,7 +99,7 @@ func (t Token) InferredType() TokenType {
 func (t Token) IsValue() bool {
 	tt := t.InferredType()
 	return tt.IsAny(FlagValueToken, ShortFlagTailToken, PositionalArgumentToken) ||
-		(tt == UntypedToken && !strings.HasPrefix(t.String(), "-"))
+		(tt == UntypedToken && !strings.HasPrefix(t.String(), delimiterDash))
 }
 
 // Scanner is a stack-based scanner over command-line tokens.

--- a/tag.go
+++ b/tag.go
@@ -147,7 +147,7 @@ func parseTagString(s string) (*Tag, error) {
 }
 
 func parseTag(parent reflect.Value, ft reflect.StructField) (*Tag, error) {
-	if ft.Tag.Get("kong") == "-" {
+	if ft.Tag.Get("kong") == delimiterDash {
 		t := newEmptyTag()
 		t.Ignored = true
 		return t, nil

--- a/utilities.go
+++ b/utilities.go
@@ -1,6 +1,11 @@
 // Package kong
 package kong
 
+import (
+	"fmt"
+	"regexp"
+)
+
 func valueOrDefaultValue(value interface{}, defaultValue interface{}) interface{} {
 	switch value.(type) {
 	case string:
@@ -18,4 +23,14 @@ func valueOrDefaultValue(value interface{}, defaultValue interface{}) interface{
 	}
 
 	return value
+}
+
+// Forced measure, where in help.go the line is not going correctly.
+func oneSpace(template string, args ...interface{}) (ret string) {
+	var (
+		rex *regexp.Regexp
+	)
+
+	rex = regexp.MustCompile(`\ +`)
+	return rex.ReplaceAllString(fmt.Sprintf(template, args...), " ")
 }

--- a/utilities.go
+++ b/utilities.go
@@ -1,0 +1,21 @@
+// Package kong
+package kong
+
+func valueOrDefaultValue(value interface{}, defaultValue interface{}) interface{} {
+	switch value.(type) {
+	case string:
+		if value == "" {
+			value = defaultValue
+		}
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		if value == 0 {
+			value = defaultValue
+		}
+	case bool:
+		if value == false {
+			value = defaultValue
+		}
+	}
+
+	return value
+}

--- a/utilities_test.go
+++ b/utilities_test.go
@@ -1,0 +1,49 @@
+// Package kong
+package kong
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestValueOrDefaultValue(t *testing.T) {
+	sv := ""
+	sd := "Default value"
+
+	// STRING
+
+	s1 := valueOrDefaultValue(sv, sd).(string)
+	require.NotEqualValues(t, sv, s1)
+	require.EqualValues(t, sd, s1)
+
+	sv = "123"
+	s2 := valueOrDefaultValue(sv, sd).(string)
+	require.NotEqualValues(t, sd, s2)
+	require.EqualValues(t, sv, s2)
+
+	// INT
+
+	iv1 := 0
+	id := 715
+	i1 := valueOrDefaultValue(iv1, id).(int)
+	require.NotEqualValues(t, iv1, i1)
+	require.EqualValues(t, id, i1)
+
+	iv1 = 300
+	i2 := valueOrDefaultValue(iv1, id).(int)
+	require.NotEqualValues(t, id, i2)
+	require.EqualValues(t, iv1, i2)
+
+	// BOOL
+
+	bv1 := false
+	bd := true
+	b1 := valueOrDefaultValue(bv1, bd).(bool)
+	require.NotEqualValues(t, bv1, b1)
+	require.EqualValues(t, bd, b1)
+
+	bv1, bd = true, false
+	b2 := valueOrDefaultValue(bv1, bd).(bool)
+	require.NotEqualValues(t, bd, b2)
+	require.EqualValues(t, bv1, b2)
+}

--- a/visit.go
+++ b/visit.go
@@ -1,8 +1,6 @@
 package kong
 
-import (
-	"fmt"
-)
+import "fmt"
 
 // Next should be called by Visitor to proceed with the walk.
 //


### PR DESCRIPTION
I did all changes, first of all, personally for myself.

* The definition of the error value in the text is not very convenient, there must be a dictionary of errors, and to compare errors with each other using equality.
* golang language works better when constants are used, they are placed in special areas of binaries
* The primary task was to localize the help, after studying, it turned out that it was not possible to do this, therefore these edits were made.

If you applies my changes, i will be very grateful.
