### PR TITLE
new HelpOption: Allow full subcommand flag display

### DIFF
--- a/_examples/shell/optionalflags/main.go
+++ b/_examples/shell/optionalflags/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"github.com/alecthomas/kong"
+)
+
+var cli struct {
+	DryRun    string `help:"optional dry run flag"`
+	Mandatory bool   `required:"" help:"mandatory global flag"`
+	Resource  struct {
+		Create struct {
+			Name string `required:"" help:"name of the resource"`
+		} `cmd:"" help:"create a resource"`
+		Delete struct {
+			Scope   string   `required:"" help:"mandatory subcommand flag"`
+			Labels  []string `help:"labels to match when deleting"`
+			Version string   `help:"version to match when deleting"`
+		} `cmd:"" help:"delete resource(s)"`
+	} `cmd:"" help:"operate on resources"`
+}
+
+func main() {
+	ctx := kong.Parse(&cli,
+		kong.Name("help"),
+		kong.Description("An app demonstrating SubcommandsWithOptionalFlags"),
+		kong.UsageOnError(),
+		kong.ConfigureHelp(kong.HelpOptions{
+			SubcommandsWithOptionalFlags: true,
+		}))
+	ctx.Run()
+}

--- a/build.go
+++ b/build.go
@@ -281,6 +281,7 @@ func buildField(k *Kong, node *Node, v reflect.Value, ft reflect.StructField, fv
 		Mapper:       mapper,
 		Tag:          tag,
 		Target:       fv,
+		Parent:       node,
 		Enum:         tag.Enum,
 		Passthrough:  tag.Passthrough,
 

--- a/help.go
+++ b/help.go
@@ -52,6 +52,11 @@ type HelpOptions struct {
 	// Don't show the help associated with subcommands
 	NoExpandSubcommands bool
 
+	// Whether to show optional flags in command summaries
+	// If true, command summaries will include flags not marked as required
+	// If false (the default), command summaries will only show required flags
+	IncludeOptionalFlagsInSummary bool
+
 	// Clamp the help wrap width to a value smaller than the terminal width.
 	// If this is set to a non-positive number, the terminal width is used; otherwise,
 	// the min of this value or the terminal width is used.
@@ -356,7 +361,7 @@ func collectCommandGroups(nodes []*Node) []helpCommandGroup {
 }
 
 func printCommandSummary(w *helpWriter, cmd *Command) {
-	w.Print(cmd.Summary())
+	w.Print(cmd.SummaryWithOptions(w.HelpOptions.IncludeOptionalFlagsInSummary))
 	if cmd.Help != "" {
 		w.Indent().Wrap(cmd.Help)
 	}

--- a/help.go
+++ b/help.go
@@ -52,10 +52,10 @@ type HelpOptions struct {
 	// Don't show the help associated with subcommands
 	NoExpandSubcommands bool
 
-	// Whether to show optional flags in command summaries
+	// Whether to include optional flags in command summaries
 	// If true, command summaries will include flags not marked as required
 	// If false (the default), command summaries will only show required flags
-	IncludeOptionalFlagsInSummary bool
+	SubcommandsWithOptionalFlags bool
 
 	// Clamp the help wrap width to a value smaller than the terminal width.
 	// If this is set to a non-positive number, the terminal width is used; otherwise,
@@ -361,7 +361,7 @@ func collectCommandGroups(nodes []*Node) []helpCommandGroup {
 }
 
 func printCommandSummary(w *helpWriter, cmd *Command) {
-	w.Print(cmd.SummaryWithOptions(w.HelpOptions.IncludeOptionalFlagsInSummary))
+	w.Print(cmd.SummaryWithOptions(w.HelpOptions.SubcommandsWithOptionalFlags))
 	if cmd.Help != "" {
 		w.Indent().Wrap(cmd.Help)
 	}

--- a/help_test.go
+++ b/help_test.go
@@ -377,7 +377,9 @@ Commands:
 //
 // MUST retain original behaviour by default (see "default" sub test)
 // MUST show optional subcommand flags when SubcommandsWithOptionalFlags
-//      is enabled (see "forced" sub test)
+//
+//	is enabled (see "forced" sub test)
+//
 // MUST show any _required_ parent flags on subcommands
 // MUST NOT show any optional parent flags on subcommands
 func TestSubcommandsWithOptionalFlags(t *testing.T) {
@@ -406,7 +408,7 @@ func TestSubcommandsWithOptionalFlags(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
 		expected := "Usage: test-app <command>\n\nA test app.\n\nFlags:\n  -h, --help    Show context-sensitive help.\n\nCommands:\n  sub more-sub --mandatory=STRING --required=STRING\n    more sub help\n\n  sub another --mandatory=STRING\n    another help\n\nRun \"test-app <command> --help\" for more information on a command.\n"
 		_, _ = app.Parse([]string{"--help"})
-		require.Equal(t, expected, w.String())
+		assert.Equal(t, expected, w.String())
 	})
 
 	w.Truncate(0)
@@ -424,7 +426,7 @@ func TestSubcommandsWithOptionalFlags(t *testing.T) {
 	t.Run("forced", func(t *testing.T) {
 		expected := "Usage: test-app <command>\n\nA test app.\n\nFlags:\n  -h, --help    Show context-sensitive help.\n\nCommands:\n  sub more-sub --mandatory=STRING --required=STRING [--flag=STRING]\n    more sub help\n\n  sub another --mandatory=STRING\n    another help\n\nRun \"test-app <command> --help\" for more information on a command.\n"
 		_, _ = app.Parse([]string{"--help"})
-		require.Equal(t, expected, w.String())
+		assert.Equal(t, expected, w.String())
 	})
 }
 

--- a/model.go
+++ b/model.go
@@ -193,15 +193,23 @@ func (n *Node) Summary() string {
 // FlagSummary for the node.
 func (n *Node) FlagSummary(hide bool, showOptional bool) string {
 	required := []string{}
+	optional := []string{}
 	count := 0
 	for _, group := range n.AllFlags(hide) {
 		for _, flag := range group {
 			count++
-			// Show required flags, or optional flags which aren't help
-			if flag.Required || (showOptional && flag.Name != "help") {
+			// Show required flags
+			if flag.Required {
 				required = append(required, flag.Summary())
+			} else if showOptional && (flag.Parent == n) {
+				// Show optional flags _if they belong to us_
+				optional = append(optional, flag.Summary())
 			}
 		}
+	}
+	if len(optional) > 0 {
+		// Group optional flags together and surround with brackets
+		required = append(required, fmt.Sprintf("[%s]", strings.Join(optional, " ")))
 	}
 	return strings.Join(required, " ")
 }
@@ -266,6 +274,7 @@ type Value struct {
 	Mapper       Mapper
 	Tag          *Tag
 	Target       reflect.Value
+	Parent       *Node
 	Required     bool
 	Set          bool   // Set to true when this value is set through some mechanism.
 	Format       string // Formatting directive, if applicable.

--- a/model.go
+++ b/model.go
@@ -141,10 +141,19 @@ func (n *Node) Depth() int {
 	return depth
 }
 
-// Summary help string for the node (not including application name).
-func (n *Node) Summary() string {
+// SummaryWithOptions help string for the node (not including application name)
+//
+// Used both by help writing as well as other parts of the application
+//
+// Most cases just use Summary() (default settings)
+//
+// The help printer uses this optional version to pass options along.
+//
+// if includeOptionalFlags is true, all flags for a command will
+// be included. see HelpOptions.IncludeOptionalFlagsInSummary
+func (n *Node) SummaryWithOptions(includeOptionalFlags bool) string {
 	summary := n.Path()
-	if flags := n.FlagSummary(true); flags != "" {
+	if flags := n.FlagSummary(true, includeOptionalFlags); flags != "" {
 		summary += " " + flags
 	}
 	args := []string{}
@@ -175,14 +184,21 @@ func (n *Node) Summary() string {
 	return summary
 }
 
+// Summary help string for the node (not including application name).
+// Default behaviour used throughout the application
+func (n *Node) Summary() string {
+	return n.SummaryWithOptions(false)
+}
+
 // FlagSummary for the node.
-func (n *Node) FlagSummary(hide bool) string {
+func (n *Node) FlagSummary(hide bool, showOptional bool) string {
 	required := []string{}
 	count := 0
 	for _, group := range n.AllFlags(hide) {
 		for _, flag := range group {
 			count++
-			if flag.Required {
+			// Show required flags, or optional flags which aren't help
+			if flag.Required || (showOptional && flag.Name != "help") {
 				required = append(required, flag.Summary())
 			}
 		}


### PR DESCRIPTION
## Problem Statement

By default, only `required` flags are displayed for subcommands

For applications with a lot of simple subcommands this obscures basic usage flags

<details>
<summary>

## Example (click to expand)

_NB: this is an entirely contrived example, but is loosely based on my real world use case_

</summary>

### Before (and still the default behaviour)

For a user to discover that there are optional flags on these subcommands they'd have to know to look

```bash
Usage: mycommand <command>

Flags:
  -h, --help                       Show context-sensitive help.

Commands:
  resource create
    Create a resource

  resource delete <name>
    Delete a resource
```

### After (and entirely optional)

Now the user can see that `resource delete` has an optional flag _without knowing to look for it_

```bash
Usage: mycommand <command>

Flags:
  -h, --help                       Show context-sensitive help.

Commands:
  resource create
    Create a resource

  resource delete [--labels=KEY=VALUE;...] <name> 
    Delete a resource
```
</details>

# Approach taken

- Add a new `HelpOption` called `SubcommandsWithOptionalFlags`
- Move `Node.Summary()` functionality into `Node.SummaryWithOptions(bool)`
    - Retain `Node.Summary()` as a default usage (forwards default
      value to `Node.SummaryWithOptions(bool)`)
- Adds `Parent` field to `Value`, allowing us to easily check whether
   a value originated with a given `Node`
    - Modify `build.go@buildField()` to include `Node` `Parent`
- Modify `help.go@printCommandSummary()` to forward the
   `HelpOption` to `Node.SummaryWithOptions()` instead of
   calling `Node.Summary()`

- When the option is enabled:
    - Groups required flags
    - Groups optional flags (by checking if the flag originated on
       the current Node)
    - Prints required flags followed by optional flags surrounded
       by brackets, eg.
       `--mandatory [ --optional1 --optional2 ]`
- Removes broken logic from previous commit checking if a flag is named `"help"`
    - Now just checks if the flag belongs to the current `Node`
- Added criteria to the test suite to confirm:
    - Default behaviour is as before
    - Ancestor's optional flags are not included
    - Ancestor's required flags are included

## Caveats

The main issue with this implementation is due to the `Node` receiver
functions doing display logic internally.  This makes sense
for most of the use cases (application error logic), but
overly restricts the help configurability

As a result:

- Must pass awkward `bool` value down from the help context
- ~~`FlagSummary()` ends up having to explicitly exclude the `help` flag - _this is particularly janky_~~ (resolved earlier)

# ~~Potential~~ Improvements ~~to be~~ made

- [x] ~~Remove explicit exclusion of `help` from `FlagSummary()`~~
    - Potentially add an equivalent `Node` receiver which just returns an
      array of flag summaries to be displayed by `help@printCommandSummary`
    - Then it's up to the help writer to decide how to render flags, and which flags to exclude _when in the help context_
- [x] ~~Change to `FlagSummary()`'s arity is a breaking change and unacceptable, seek alternative~~
    - See [original comment](https://github.com/alecthomas/kong/pull/306/files#r975322296)
    - Updated to instead add a few duplicated lines whilst avoiding changing existing function arity