### PR TITLE
fix: change VersionFlag to a BeforeReset hook

### DIFF
--- a/kong_test.go
+++ b/kong_test.go
@@ -1544,7 +1544,8 @@ func TestPassthroughCmdOnlyStringArgs(t *testing.T) {
 
 func TestHelpShouldStillWork(t *testing.T) {
 	type CLI struct {
-		Dir string `type:"existingdir" default:"missing-dir"`
+		Dir  string `type:"existingdir" default:"missing-dir"`
+		File string `type:"existingfile" default:"testdata/missing.txt"`
 	}
 	var cli CLI
 	w := &strings.Builder{}
@@ -1554,6 +1555,29 @@ func TestHelpShouldStillWork(t *testing.T) {
 		rc = i
 	}
 	_, err := k.Parse([]string{"--help"})
+	t.Log(w.String())
+	// checking return code validates the help hook was called
+	assert.Zero(t, rc)
+	// allow for error propagation from other validation (only for the
+	// sake of this test, due to the exit function not actually exiting the
+	// program; errors will not propagate in the real world).
+	assert.Error(t, err)
+}
+
+func TestVersionFlagShouldStillWork(t *testing.T) {
+	type CLI struct {
+		Dir     string `type:"existingdir" default:"missing-dir"`
+		File    string `type:"existingfile" default:"testdata/missing.txt"`
+		Version kong.VersionFlag
+	}
+	var cli CLI
+	w := &strings.Builder{}
+	k := mustNew(t, &cli, kong.Writers(w, w))
+	rc := -1 // init nonzero to help assert help hook was called
+	k.Exit = func(i int) {
+		rc = i
+	}
+	_, err := k.Parse([]string{"--version"})
 	t.Log(w.String())
 	// checking return code validates the help hook was called
 	assert.Zero(t, rc)

--- a/util.go
+++ b/util.go
@@ -29,8 +29,8 @@ func (c ConfigFlag) BeforeResolve(kong *Kong, ctx *Context, trace *Path) error {
 // VersionFlag is a flag type that can be used to display a version number, stored in the "version" variable.
 type VersionFlag bool
 
-// BeforeApply writes the version variable and terminates with a 0 exit status.
-func (v VersionFlag) BeforeApply(app *Kong, vars Vars) error {
+// BeforeReset writes the version variable and terminates with a 0 exit status.
+func (v VersionFlag) BeforeReset(app *Kong, vars Vars) error {
 	fmt.Fprintln(app.Stdout, vars["version"])
 	app.Exit(0)
 	return nil


### PR DESCRIPTION
Similar to how `--help` was updated in https://github.com/alecthomas/kong/pull/298, `--version` changed to a BeforeReset hook so that it will always work.