### PR TITLE
fix: placeholder quoting

### DIFF
--- a/model.go
+++ b/model.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"os"
 	"reflect"
-	"strconv"
 	"strings"
 )
 
@@ -422,7 +421,7 @@ func (f *Flag) FormatPlaceHolder() string {
 	}
 	if f.HasDefault {
 		if f.Value.Target.Kind() == reflect.String {
-			return strconv.Quote(f.Default) + tail
+			return fmt.Sprintf(`"%s"%s`, f.Default, tail)
 		}
 		return f.Default + tail
 	}


### PR DESCRIPTION
Closes #324 

- Originally `strconv.Quote()` was used to escape the string
- `Quote()` escaped sequences such as `\t`
- This was unwanted behavior
- Now it's replaced with adding quotes manually