### PR TITLE
Cumulative argument needs to be last

### DIFF
--- a/build.go
+++ b/build.go
@@ -171,17 +171,25 @@ MAIN:
 		}
 	}
 
+	if err := validatePositionalArguments(node); err != nil {
+		return nil, err
+	}
+
+	return node, nil
+}
+
+func validatePositionalArguments(node *Node) error {
 	var last *Value
 	for i, curr := range node.Positional {
 		if last != nil {
 			// Scan through argument positionals to ensure optional is never before a required.
 			if !last.Required && curr.Required {
-				return nil, fmt.Errorf("%s: required %q cannot come after optional %q", node.FullPath(), curr.Name, last.Name)
+				return fmt.Errorf("%s: required %q cannot come after optional %q", node.FullPath(), curr.Name, last.Name)
 			}
 
 			// Cumulative argument needs to be last.
 			if last.IsCumulative() {
-				return nil, fmt.Errorf("%s: argument %q cannot come after cumulative %q", node.FullPath(), curr.Name, last.Name)
+				return fmt.Errorf("%s: argument %q cannot come after cumulative %q", node.FullPath(), curr.Name, last.Name)
 			}
 		}
 
@@ -189,7 +197,7 @@ MAIN:
 		curr.Position = i
 	}
 
-	return node, nil
+	return nil
 }
 
 func buildChild(k *Kong, node *Node, typ NodeType, v reflect.Value, ft reflect.StructField, fv reflect.Value, tag *Tag, name string, seenFlags map[string]bool) error {

--- a/build.go
+++ b/build.go
@@ -171,12 +171,20 @@ MAIN:
 		}
 	}
 
-	// Scan through argument positionals to ensure optional is never before a required.
 	var last *Value
 	for i, curr := range node.Positional {
-		if last != nil && !last.Required && curr.Required {
-			return nil, fmt.Errorf("%s: required %q can not come after optional %q", node.FullPath(), curr.Name, last.Name)
+		if last != nil {
+			// Scan through argument positionals to ensure optional is never before a required.
+			if !last.Required && curr.Required {
+				return nil, fmt.Errorf("%s: required %q cannot come after optional %q", node.FullPath(), curr.Name, last.Name)
+			}
+
+			// Cumulative argument needs to be last.
+			if last.IsCumulative() {
+				return nil, fmt.Errorf("%s: argument %q cannot come after cumulative %q", node.FullPath(), curr.Name, last.Name)
+			}
 		}
+
 		last = curr
 		curr.Position = i
 	}

--- a/kong_test.go
+++ b/kong_test.go
@@ -1718,3 +1718,21 @@ func TestChildNameCanBeDuplicated(t *testing.T) {
 	}
 	mustNew(t, &cli)
 }
+
+func TestCumulativeArgumentLast(t *testing.T) {
+	var cli struct {
+		Arg1 string   `arg:""`
+		Arg2 []string `arg:""`
+	}
+	_, err := kong.New(&cli)
+	assert.NoError(t, err)
+}
+
+func TestCumulativeArgumentNotLast(t *testing.T) {
+	var cli struct {
+		Arg2 []string `arg:""`
+		Arg1 string   `arg:""`
+	}
+	_, err := kong.New(&cli)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Closes #276

No other arguments can be after a cumulative argument.
This excludes required positional arguments such as `cmd <arg> ... <last>`.

I believe the best practice shall be - cumulative arguments are always last.
Let me know if you think required arguments shall be supported after cumulative. I'll be happy to update the PR.