### PR TITLE
Fix loading large integers from JSON files

### DIFF
--- a/mapper.go
+++ b/mapper.go
@@ -363,8 +363,11 @@ func intDecoder(bits int) MapperFunc { // nolint: dupl
 		case string:
 			sv = v
 
-		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
 			sv = fmt.Sprintf("%v", v)
+
+		case float32, float64:
+			sv = fmt.Sprintf("%0.f", v)
 
 		default:
 			return fmt.Errorf("expected an int but got %q (%T)", t, t.Value)

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -400,7 +400,8 @@ func TestNumbers(t *testing.T) {
 	})
 }
 
-func TestJsonBigNumber(t *testing.T) {
+func TestJSONLargeNumber(t *testing.T) {
+	// https://github.com/alecthomas/kong/pull/334/files
 	const n = 1000000
 	var cli struct {
 		N int64

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -401,7 +401,7 @@ func TestNumbers(t *testing.T) {
 }
 
 func TestJSONLargeNumber(t *testing.T) {
-	// https://github.com/alecthomas/kong/pull/334/files
+	// https://github.com/alecthomas/kong/pull/334
 	const n = 1000000
 	var cli struct {
 		N int64

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -400,6 +400,20 @@ func TestNumbers(t *testing.T) {
 	})
 }
 
+func TestJsonBigNumber(t *testing.T) {
+	const n = 1000000
+	var cli struct {
+		N int64
+	}
+	json := fmt.Sprintf(`{"n": %d}`, n)
+	r, err := kong.JSON(strings.NewReader(json))
+	assert.NoError(t, err)
+	parser := mustNew(t, &cli, kong.Resolvers(r))
+	_, err = parser.Parse([]string{})
+	assert.NoError(t, err)
+	assert.Equal(t, n, cli.N)
+}
+
 func TestFileMapper(t *testing.T) {
 	type CLI struct {
 		File *os.File `arg:""`


### PR DESCRIPTION
`%v` uses E notation to format floats with more than 6 digits. Since JSON numbers are always floats, Kong breaks when loading large integers from JSON files.