### PR TITLE
Fix large number decoding for unsigned types in JSON

### DIFF
--- a/mapper.go
+++ b/mapper.go
@@ -392,8 +392,11 @@ func uintDecoder(bits int) MapperFunc { // nolint: dupl
 		case string:
 			sv = v
 
-		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
 			sv = fmt.Sprintf("%v", v)
+
+		case float32, float64:
+			sv = fmt.Sprintf("%0.f", v)
 
 		default:
 			return fmt.Errorf("expected an int but got %q (%T)", t, t.Value)


### PR DESCRIPTION
I noticed that after merging [the fix for large numbers (#334)](https://github.com/alecthomas/kong/pull/334), the build was broken on the `master` branch [due to a linter complaint](https://github.com/alecthomas/kong/actions/runs/3101957356/jobs/5023801376).

Problem is that the `uintDecoder` is no longer a code duplication of `intDecoder`, because the adjustments by #334 only changed `intDecoder`. It’s not the linter directive that’s obsolete, but I rather think that `uintDecoder` must have that fix as well, because it suffers from the same problem.

In addition to the actual fix, I slightly adjusted the tests:

- I converted the Github link to an inlined explanation, just for convenience.
- Both cases for `int` and `uint` are now covered. I think it makes sense to have them together in one single test, since they are so closely related. I enclosed each one in a block, so that they have their own scope.
- For the sake of completeness/consistency, I added another test for floats, which covers the `floatDecoder`.
- Instead of having a helper variable `n` in the test, I think it’s more robust to inline the number. That way, we don’t rely on how `fmt.Sprintf` would serialise the number within the test.
- Writing `n := 100000` would infer the type to `int`, but [`int` is platform-dependent](https://go.dev/tour/basics/11). It’s safer to assign the type explicitly (e.g. `int64`), to make the test deterministic.

One note aside: the tests don’t seem to be run on PRs. Maybe that could be fixed, which would uncover build failures before they go into the `master` branch.