### PR TITLE
feat: Embed() option and Context.Call()

### DIFF
--- a/build.go
+++ b/build.go
@@ -25,7 +25,7 @@ func build(k *Kong, ast interface{}) (app *Application, err error) {
 		seenFlags[flag.Name] = true
 	}
 
-	node, err := buildNode(k, iv, ApplicationNode, seenFlags)
+	node, err := buildNode(k, iv, ApplicationNode, newEmptyTag(), seenFlags)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ type flattenedField struct {
 	tag   *Tag
 }
 
-func flattenedFields(v reflect.Value) (out []flattenedField, err error) {
+func flattenedFields(v reflect.Value, ptag *Tag) (out []flattenedField, err error) {
 	v = reflect.Indirect(v)
 	for i := 0; i < v.NumField(); i++ {
 		ft := v.Type().Field(i)
@@ -61,6 +61,15 @@ func flattenedFields(v reflect.Value) (out []flattenedField, err error) {
 		if tag.Ignored {
 			continue
 		}
+		// Assign group if it's not already set.
+		if tag.Group == "" {
+			tag.Group = ptag.Group
+		}
+		// Accumulate prefixes.
+		tag.Prefix = ptag.Prefix + tag.Prefix
+		tag.EnvPrefix = ptag.EnvPrefix + tag.EnvPrefix
+		// Combine parent vars.
+		tag.Vars = ptag.Vars.CloneWith(tag.Vars)
 		// Command and embedded structs can be pointers, so we hydrate them now.
 		if (tag.Cmd || tag.Embed) && ft.Type.Kind() == reflect.Ptr {
 			fv = reflect.New(ft.Type.Elem()).Elem()
@@ -68,7 +77,8 @@ func flattenedFields(v reflect.Value) (out []flattenedField, err error) {
 		}
 		if !ft.Anonymous && !tag.Embed {
 			if fv.CanSet() {
-				out = append(out, flattenedField{field: ft, value: fv, tag: tag})
+				field := flattenedField{field: ft, value: fv, tag: tag}
+				out = append(out, field)
 			}
 			continue
 		}
@@ -78,7 +88,7 @@ func flattenedFields(v reflect.Value) (out []flattenedField, err error) {
 			fv = fv.Elem()
 		} else if fv.Type() == reflect.TypeOf(Plugins{}) {
 			for i := 0; i < fv.Len(); i++ {
-				fields, ferr := flattenedFields(fv.Index(i).Elem())
+				fields, ferr := flattenedFields(fv.Index(i).Elem(), tag)
 				if ferr != nil {
 					return nil, ferr
 				}
@@ -86,20 +96,9 @@ func flattenedFields(v reflect.Value) (out []flattenedField, err error) {
 			}
 			continue
 		}
-		sub, err := flattenedFields(fv)
+		sub, err := flattenedFields(fv, tag)
 		if err != nil {
 			return nil, err
-		}
-		for _, subf := range sub {
-			// Assign parent if it's not already set.
-			if subf.tag.Group == "" {
-				subf.tag.Group = tag.Group
-			}
-			// Accumulate prefixes.
-			subf.tag.Prefix = tag.Prefix + subf.tag.Prefix
-			subf.tag.EnvPrefix = tag.EnvPrefix + subf.tag.EnvPrefix
-			// Combine parent vars.
-			subf.tag.Vars = tag.Vars.CloneWith(subf.tag.Vars)
 		}
 		out = append(out, sub...)
 	}
@@ -109,13 +108,13 @@ func flattenedFields(v reflect.Value) (out []flattenedField, err error) {
 // Build a Node in the Kong data model.
 //
 // "v" is the value to create the node from, "typ" is the output Node type.
-func buildNode(k *Kong, v reflect.Value, typ NodeType, seenFlags map[string]bool) (*Node, error) {
+func buildNode(k *Kong, v reflect.Value, typ NodeType, tag *Tag, seenFlags map[string]bool) (*Node, error) {
 	node := &Node{
 		Type:   typ,
 		Target: v,
-		Tag:    newEmptyTag(),
+		Tag:    tag,
 	}
-	fields, err := flattenedFields(v)
+	fields, err := flattenedFields(v, tag)
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +200,7 @@ func validatePositionalArguments(node *Node) error {
 }
 
 func buildChild(k *Kong, node *Node, typ NodeType, v reflect.Value, ft reflect.StructField, fv reflect.Value, tag *Tag, name string, seenFlags map[string]bool) error {
-	child, err := buildNode(k, fv, typ, seenFlags)
+	child, err := buildNode(k, fv, typ, newEmptyTag(), seenFlags)
 	if err != nil {
 		return err
 	}

--- a/callbacks.go
+++ b/callbacks.go
@@ -74,11 +74,14 @@ func getMethod(value reflect.Value, name string) reflect.Value {
 	return method
 }
 
-func callMethod(name string, v, f reflect.Value, bindings bindings) error {
+func callFunction(f reflect.Value, bindings bindings) error {
+	if f.Kind() != reflect.Func {
+		return fmt.Errorf("expected function, got %s", f.Type())
+	}
 	in := []reflect.Value{}
 	t := f.Type()
 	if t.NumOut() != 1 || !t.Out(0).Implements(callbackReturnSignature) {
-		return fmt.Errorf("return value of %T.%s() must implement \"error\"", v.Type(), name)
+		return fmt.Errorf("return value of %s must implement \"error\"", t)
 	}
 	for i := 0; i < t.NumIn(); i++ {
 		pt := t.In(i)
@@ -89,7 +92,7 @@ func callMethod(name string, v, f reflect.Value, bindings bindings) error {
 			}
 			in = append(in, argv)
 		} else {
-			return fmt.Errorf("couldn't find binding of type %s for parameter %d of %s.%s(), use kong.Bind(%s)", pt, i, v.Type(), name, pt)
+			return fmt.Errorf("couldn't find binding of type %s for parameter %d of %s(), use kong.Bind(%s)", pt, i, t, pt)
 		}
 	}
 	out := f.Call(in)
@@ -97,4 +100,38 @@ func callMethod(name string, v, f reflect.Value, bindings bindings) error {
 		return nil
 	}
 	return out[0].Interface().(error) // nolint
+}
+
+func callAnyFunction(f reflect.Value, bindings bindings) (out []any, err error) {
+	if f.Kind() != reflect.Func {
+		return nil, fmt.Errorf("expected function, got %s", f.Type())
+	}
+	in := []reflect.Value{}
+	t := f.Type()
+	for i := 0; i < t.NumIn(); i++ {
+		pt := t.In(i)
+		if argf, ok := bindings[pt]; ok {
+			argv, err := argf()
+			if err != nil {
+				return nil, err
+			}
+			in = append(in, argv)
+		} else {
+			return nil, fmt.Errorf("couldn't find binding of type %s for parameter %d of %s(), use kong.Bind(%s)", pt, i, t, pt)
+		}
+	}
+	outv := f.Call(in)
+	out = make([]any, len(outv))
+	for i, v := range outv {
+		out[i] = v.Interface()
+	}
+	return out, nil
+}
+
+func callMethod(name string, v, f reflect.Value, bindings bindings) error {
+	err := callFunction(f, bindings)
+	if err != nil {
+		return fmt.Errorf("%s.%s(): %w", v.Type(), name, err)
+	}
+	return nil
 }

--- a/context.go
+++ b/context.go
@@ -110,7 +110,7 @@ func (c *Context) Bind(args ...interface{}) {
 //
 // This will typically have to be called like so:
 //
-//    BindTo(impl, (*MyInterface)(nil))
+//	BindTo(impl, (*MyInterface)(nil))
 func (c *Context) BindTo(impl, iface interface{}) {
 	c.bindings.addTo(impl, iface)
 }
@@ -717,6 +717,13 @@ func (c *Context) parseFlag(flags []*Flag, match string) (err error) {
 		return nil
 	}
 	return findPotentialCandidates(match, candidates, "unknown flag %s", match)
+}
+
+// Call an arbitrary function filling arguments with bound values.
+func (c *Context) Call(fn any, binds ...interface{}) (out []interface{}, err error) {
+	fv := reflect.ValueOf(fn)
+	bindings := c.Kong.bindings.clone().add(binds...).add(c).merge(c.bindings) //nolint:govet
+	return callAnyFunction(fv, bindings)
 }
 
 // RunNode calls the Run() method on an arbitrary node.

--- a/options_test.go
+++ b/options_test.go
@@ -58,7 +58,7 @@ func TestInvalidCallback(t *testing.T) {
 	p, err := New(&cli, BindTo(impl("foo"), (*iface)(nil)))
 	assert.NoError(t, err)
 	err = callMethod("method", reflect.ValueOf(impl("??")), reflect.ValueOf(method), p.bindings)
-	assert.EqualError(t, err, `return value of *reflect.rtype.method() must implement "error"`)
+	assert.EqualError(t, err, `kong.impl.method(): return value of func(kong.iface) string must implement "error"`)
 }
 
 type zrror struct{}

--- a/tag.go
+++ b/tag.go
@@ -44,6 +44,16 @@ type Tag struct {
 	items map[string][]string
 }
 
+func (t *Tag) String() string {
+	out := []string{}
+	for key, list := range t.items {
+		for _, value := range list {
+			out = append(out, fmt.Sprintf("%s:%q", key, value))
+		}
+	}
+	return strings.Join(out, " ")
+}
+
 type tagChars struct {
 	sep, quote, assign rune
 }


### PR DESCRIPTION
The former allows arbitrary structs to be embedded in the root of the CLI, with optional tags.

The latter allows an arbitrary function to be called using Kong's binding functionality.