### PR TITLE
Support string pointers for path mapper

### DIFF
--- a/mapper.go
+++ b/mapper.go
@@ -574,6 +574,12 @@ func pathMapper(r *Registry) MapperFunc {
 		if target.Kind() == reflect.Slice {
 			return sliceDecoder(r)(ctx, target)
 		}
+		if target.Kind() == reflect.Ptr && target.Elem().Kind() == reflect.String {
+			if target.IsNil() {
+				return nil
+			}
+			target = target.Elem()
+		}
 		if target.Kind() != reflect.String {
 			return fmt.Errorf("\"path\" type must be applied to a string not %s", target.Type())
 		}

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -488,6 +488,49 @@ func TestFileContentMapper(t *testing.T) {
 	assert.Contains(t, err.Error(), "is a directory")
 }
 
+func TestPathMapperUsingStringPointer(t *testing.T) {
+	type CLI struct {
+		Path *string `type:"path"`
+	}
+	var cli CLI
+
+	t.Run("With value", func(t *testing.T) {
+		p := mustNew(t, &cli)
+		_, err := p.Parse([]string{"--path", "/foo/bar"})
+		assert.NoError(t, err)
+		assert.NotZero(t, cli.Path)
+		assert.Equal(t, "/foo/bar", *cli.Path)
+	})
+
+	t.Run("Zero value", func(t *testing.T) {
+		p := mustNew(t, &cli)
+		_, err := p.Parse([]string{"--path", ""})
+		assert.NoError(t, err)
+		assert.NotZero(t, cli.Path)
+		wd, err := os.Getwd()
+		assert.NoError(t, err)
+		assert.Equal(t, wd, *cli.Path)
+	})
+
+	t.Run("Without value", func(t *testing.T) {
+		p := mustNew(t, &cli)
+		_, err := p.Parse([]string{"--"})
+		assert.NoError(t, err)
+		assert.Equal(t, nil, cli.Path)
+	})
+
+	t.Run("Non-string pointer", func(t *testing.T) {
+		type CLI struct {
+			Path *any `type:"path"`
+		}
+		var cli CLI
+		p := mustNew(t, &cli)
+		_, err := p.Parse([]string{"--path", ""})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), `"path" type must be applied to a string`)
+	})
+}
+
 //nolint:dupl
 func TestExistingFileMapper(t *testing.T) {
 	type CLI struct {


### PR DESCRIPTION
I have a use case where I would like to differentiate between an unset path and an empty string path (which expands to the current directory).

This PR updates the `pathMapper` function to allow a `path` type to be applied to a `*string` to make this differentiation per the pointer behaviour described here: https://github.com/alecthomas/kong#pointers