### PR TITLE
Add SetToDefault bool for presenting whether a flag is set to the default or not

### DIFF
--- a/model.go
+++ b/model.go
@@ -246,6 +246,7 @@ type Value struct {
 	Position     int    // Position (for positional arguments).
 	Passthrough  bool   // Set to true to stop flag parsing when encountered.
 	Active       bool   // Denotes the value is part of an active branch in the CLI.
+	SetToDefault bool   // Set to true when this value is set to default value.
 }
 
 // EnumMap returns a map of the enums in this value.
@@ -380,6 +381,9 @@ func (v *Value) Reset() error {
 		}
 	}
 	if v.HasDefault {
+		if !v.Set {
+			v.SetToDefault = true
+		}
 		return v.Parse(ScanFromTokens(Token{Type: FlagValueToken, Value: v.Default}), v.Target)
 	}
 	return nil


### PR DESCRIPTION
Fix: #365 

This PR adds a new API field: `SetToDefault`. This new field will present whether a flag is set to the default or not.