### PR TITLE
fix: remove showing app name twice in errors

### DIFF
--- a/context.go
+++ b/context.go
@@ -201,7 +201,7 @@ func (c *Context) Validate() error { // nolint: gocyclo
 
 		case *Application:
 			value = node.Target
-			desc = node.Name
+			desc = ""
 
 		case *Node:
 			value = node.Target
@@ -209,7 +209,10 @@ func (c *Context) Validate() error { // nolint: gocyclo
 		}
 		if validate := isValidatable(value); validate != nil {
 			if err := validate.Validate(); err != nil {
-				return fmt.Errorf("%s: %w", desc, err)
+				if desc != "" {
+					return fmt.Errorf("%s: %w", desc, err)
+				}
+				return err
 			}
 		}
 	}

--- a/kong_test.go
+++ b/kong_test.go
@@ -1214,7 +1214,7 @@ func TestValidateApp(t *testing.T) {
 	cli := validateCli{}
 	p := mustNew(t, &cli)
 	_, err := p.Parse([]string{})
-	assert.EqualError(t, err, "test: app error")
+	assert.EqualError(t, err, "app error")
 }
 
 func TestValidateCmd(t *testing.T) {


### PR DESCRIPTION
Fixes #332.

So there is no need to prepend the app name at this point because `kong.Errorf` prepends all outputs with app name already. So the app-level failures should just return the error. Only when it is deeper we need additional information about the node where the error is coming from.