### PR TITLE
Remove extra newline when message contains trailing newlines

### DIFF
--- a/kong.go
+++ b/kong.go
@@ -373,7 +373,7 @@ func (k *Kong) applyHookToDefaultFlags(ctx *Context, node *Node, name string) er
 }
 
 func formatMultilineMessage(w io.Writer, leaders []string, format string, args ...interface{}) {
-	lines := strings.Split(fmt.Sprintf(format, args...), "\n")
+	lines := strings.Split(strings.TrimRight(fmt.Sprintf(format, args...), "\n"), "\n")
 	leader := ""
 	for _, l := range leaders {
 		if l == "" {

--- a/kong_test.go
+++ b/kong_test.go
@@ -582,11 +582,24 @@ func TestSliceWithDisabledSeparator(t *testing.T) {
 }
 
 func TestMultilineMessage(t *testing.T) {
-	w := &bytes.Buffer{}
-	var cli struct{}
-	p := mustNew(t, &cli, kong.Writers(w, w))
-	p.Printf("hello\nworld")
-	assert.Equal(t, "test: hello\n      world\n", w.String())
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{"Simple", "hello\nworld", "test: hello\n      world\n"},
+		{"WithNewline", "hello\nworld\n", "test: hello\n      world\n"},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			w := &bytes.Buffer{}
+			var cli struct{}
+			p := mustNew(t, &cli, kong.Writers(w, w))
+			p.Printf(test.text)
+			assert.Equal(t, test.want, w.String())
+		})
+	}
 }
 
 type cmdWithRun struct {


### PR DESCRIPTION
If there is trailing newline, `strings.Split` creates an empty last line in `lines`, making this function output an extra empty line at the end. Trimming trailing newlines fixes that.