### PR TITLE
Drop references to io/ioutil

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,7 +76,6 @@ issues:
     - 'bad syntax for struct tag key'
     - 'bad syntax for struct tag pair'
     - 'result .* \(error\) is always nil'
-    - 'package io/ioutil is deprecated'
 
   exclude-rules:
     # Don't warn on unused parameters.

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ var cli struct {
 
 func main() {
   // Debug logger going to discard.
-  logger := log.New(ioutil.Discard, "", log.LstdFlags)
+  logger := log.New(io.Discard, "", log.LstdFlags)
 
   ctx := kong.Parse(&cli, kong.Bind(logger))
 

--- a/config_test.go
+++ b/config_test.go
@@ -2,7 +2,6 @@ package kong_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -45,7 +44,7 @@ func TestConfigValidation(t *testing.T) {
 
 func makeConfig(t *testing.T, config interface{}) (path string, cleanup func()) {
 	t.Helper()
-	w, err := ioutil.TempFile("", "")
+	w, err := os.CreateTemp("", "")
 	assert.NoError(t, err)
 	defer w.Close()
 	err = json.NewEncoder(w).Encode(config)

--- a/mapper.go
+++ b/mapper.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/bits"
 	"net/url"
 	"os"
@@ -712,9 +712,9 @@ func fileContentMapper(r *Registry) MapperFunc {
 		var data []byte
 		if path != "-" {
 			path = ExpandPath(path)
-			data, err = ioutil.ReadFile(path) //nolint:gosec
+			data, err = os.ReadFile(path) //nolint:gosec
 		} else {
-			data, err = ioutil.ReadAll(os.Stdin)
+			data, err = io.ReadAll(os.Stdin)
 		}
 		if err != nil {
 			if info, statErr := os.Stat(path); statErr == nil && info.IsDir() {
@@ -884,7 +884,7 @@ func (f *NamedFileContentFlag) Decode(ctx *DecodeContext) error { //nolint: revi
 		return nil
 	}
 	filename = ExpandPath(filename)
-	data, err := ioutil.ReadFile(filename) //nolint: gosec
+	data, err := os.ReadFile(filename) //nolint: gosec
 	if err != nil {
 		return fmt.Errorf("failed to open %q: %v", filename, err)
 	}
@@ -908,7 +908,7 @@ func (f *FileContentFlag) Decode(ctx *DecodeContext) error { //nolint: revive
 		return nil
 	}
 	filename = ExpandPath(filename)
-	data, err := ioutil.ReadFile(filename) //nolint: gosec
+	data, err := os.ReadFile(filename) //nolint: gosec
 	if err != nil {
 		return fmt.Errorf("failed to open %q: %v", filename, err)
 	}

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"net/url"
 	"os"
@@ -269,7 +268,7 @@ func TestFileContentFlag(t *testing.T) {
 	var cli struct {
 		File kong.FileContentFlag
 	}
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	assert.NoError(t, err)
 	defer os.Remove(f.Name())
 	fmt.Fprint(f, "hello world")
@@ -283,7 +282,7 @@ func TestNamedFileContentFlag(t *testing.T) {
 	var cli struct {
 		File kong.NamedFileContentFlag
 	}
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	assert.NoError(t, err)
 	defer os.Remove(f.Name())
 	fmt.Fprint(f, "hello world")

--- a/util_test.go
+++ b/util_test.go
@@ -1,7 +1,6 @@
 package kong
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -17,7 +16,7 @@ func TestConfigFlag(t *testing.T) {
 		Flag   string
 	}
 
-	w, err := ioutil.TempFile("", "")
+	w, err := os.CreateTemp("", "")
 	assert.NoError(t, err)
 	defer os.Remove(w.Name())
 	w.WriteString(`{"flag": "hello world"}`) //nolint: errcheck


### PR DESCRIPTION
io/ioutil has been deprecated for a while.
Replace all uses of it with equivalent APIs.
