### PR TITLE
ci: Test against Go 1.20 and 1.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,28 +4,45 @@ on:
       - master
   pull_request:
 name: CI
+
 jobs:
   test:
-    name: Test
+    name: Test / Go ${{ matrix.go }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # These are the release channels.
+        # Hermit will handle installing the right patch.
+        go: ["1.20", "1.21"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Init Hermit
         run: ./bin/hermit env -r >> "$GITHUB_ENV"
+      - name: Install Go ${{ matrix.go }}
+        run: |
+          hermit install go@"${GO_VERSION}"
+          go version
+        env:
+          GO_VERSION: ${{ matrix.go }}
       - name: Test
         run: go test ./...
 
   test-windows:
-    name: Test / Windows
+    name: Test / Windows / Go ${{ matrix.go }}
     runs-on: windows-latest
+    strategy:
+      matrix:
+        # These are versions for GitHub's setup-go.
+        # '.x' will pick the latest patch release.
+        go: ["1.20.x", "1.21.x"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: ${{ matrix.go }}
       - name: Test
         run: go test ./...
 


### PR DESCRIPTION
Per the [Go Release Policy][1], upstream supports
only the two most recent major releases of Go.
For example, with Go 1.21 available, only 1.21 and 1.20 are supported.
Many projects adopt a similar support policy
to strike a balance between new features and backwards support.

  [1]: https://go.dev/doc/devel/release#policy

If Kong has the same policy,
it makes sense to test against both versions of Go.

This change adds a test matrix to CI,
testing against both Go 1.20 and 1.21,
on both Windows and Linux.

For Linux, it installs the desired version on demand,
because I couldn't find a way to have multiple versions
coexist with Hermit.