### PR TITLE
Add an example for implementing custom resolver that uses HTTP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,7 +703,9 @@ kong.Parse(&cli, kong.Configuration(kong.JSON, "/etc/myapp.json", "~/.myapp.json
 
 Resolvers are Kong's extension point for providing default values from external sources. As an example, support for environment variables via the `env` tag is provided by a resolver. There's also a builtin resolver for JSON configuration files.
 
-Example resolvers can be found in [resolver.go](https://github.com/alecthomas/kong/blob/master/resolver.go).
+Example resolvers can be found in
+- [resolver.go](https://github.com/alecthomas/kong/blob/master/resolver.go)
+- [custom-tag-resolver][https://github.com/alecthomas/kong/blob/master/_examples/custom-tag-resolver/main.go]
 
 ### `*Mapper(...)` - customising how the command-line is mapped to Go values
 

--- a/_examples/custom-tag-resolver/go.mod
+++ b/_examples/custom-tag-resolver/go.mod
@@ -1,0 +1,7 @@
+module kong-custom-resolver
+
+go 1.21
+
+require github.com/alecthomas/kong v0.8.1
+
+replace github.com/alecthomas/kong => ../../

--- a/_examples/custom-tag-resolver/go.sum
+++ b/_examples/custom-tag-resolver/go.sum
@@ -1,0 +1,6 @@
+github.com/alecthomas/assert/v2 v2.5.0 h1:OJKYg53BQx06/bMRBSPDCO49CbCDNiUQXwdoNrt6x5w=
+github.com/alecthomas/assert/v2 v2.5.0/go.mod h1:fw5suVxB+wfYJ3291t0hRTqtGzFYdSwstnRQdaQx2DM=
+github.com/alecthomas/repr v0.3.0 h1:NeYzUPfjjlqHY4KtzgKJiWd6sVq2eNUPTi34PiFGjY8=
+github.com/alecthomas/repr v0.3.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=

--- a/_examples/custom-tag-resolver/main.go
+++ b/_examples/custom-tag-resolver/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/alecthomas/kong"
+)
+
+// MyResolver is a custom resolver that resolves the value of a flag from an HTTP endpoint.
+func MyResolver(baseEndpoint string) kong.Resolver {
+	return kong.ResolverFunc((func(_ *kong.Context, _ *kong.Path, flag *kong.Flag) (interface{}, error) {
+		// NOTE: Since all flags are resolved using this resolver, you should check if the flag should be resolved by this resolver.
+		// returning nil for the left value means that the flag should not be resolved by this resolver.
+		if flag.Tag.Get("http_path") == "" {
+			return nil, nil
+		}
+		resp, err := http.Get(baseEndpoint + flag.Tag.Get("http_path"))
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+		buf, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		return string(buf), nil
+	}))
+}
+
+func main() {
+	count := 0
+	go func() {
+		http.HandleFunc("/secret-path/1", func(w http.ResponseWriter, r *http.Request) {
+			count++
+			w.Write([]byte("secret-value1"))
+		})
+		http.HandleFunc("/secret-path/3", func(w http.ResponseWriter, r *http.Request) {
+			count++
+			w.Write([]byte("secret-value3"))
+		})
+		http.ListenAndServe(":8080", nil)
+	}()
+
+	var cli struct {
+		Flag1 string `kong:"http_path='/secret-path/1'"`    // resolve the value from "localhost:8080/secret-path/1"
+		Flag2 string `kong:"default='default-flag2-value'"` // this flag will not be resolved by MyResolver
+		Flag3 string `kong:"http_path='/secret-path/3'"`    // resolve the value from "localhost:8080/secret-path/3"
+	}
+	parser := kong.Must(&cli, kong.Resolvers(MyResolver("http://localhost:8080")))
+	_, err := parser.Parse([]string{})
+	if err != nil {
+		panic(err)
+	}
+
+	// print the resolved values
+	fmt.Printf("%+v\n", cli)
+	// print the number of requests, it should be 2
+	fmt.Printf("number of requests: %d\n", count)
+}


### PR DESCRIPTION
Thank you for an awesome and useful library! I'm reaching out to contribute a new example that demonstrates how to implement a custom resolver by using HTTP request.  I look forward to your feedback and hope to contribute positively to the Kong.