### PR TITLE
Aliases can be duplicated between different sub commands

### DIFF
--- a/build.go
+++ b/build.go
@@ -170,6 +170,9 @@ MAIN:
 		if flag.Short != 0 {
 			delete(seenFlags, "-"+string(flag.Short))
 		}
+		for _, aflag := range flag.Aliases {
+			delete(seenFlags, "--"+aflag)
+		}
 	}
 
 	if err := validatePositionalArguments(node); err != nil {

--- a/kong_test.go
+++ b/kong_test.go
@@ -1340,6 +1340,20 @@ func TestDuplicateAliases(t *testing.T) {
 	assert.EqualError(t, err, "<anonymous struct>.Flag2: duplicate flag --flag")
 }
 
+func TestSubCommandAliases(t *testing.T) {
+	type SubC struct {
+		Flag1 string `aliases:"flag"`
+	}
+
+	cli1 := struct {
+		Sub1 SubC `cmd:"sub1"`
+		Sub2 SubC `cmd:"sub2"`
+	}{}
+
+	_, err := kong.New(&cli1)
+	assert.NoError(t, err, "dupe aliases shouldn't error if they're in separate sub commands")
+}
+
 func TestDuplicateAliasLong(t *testing.T) {
 	cli2 := struct {
 		Flag  string ``


### PR DESCRIPTION
Make sure we remove all the aliases from the seenFlags tracker just like we do with other flags/short flags