### PR TITLE
feat: allow non-structs to be used as commands

### DIFF
--- a/build.go
+++ b/build.go
@@ -51,6 +51,9 @@ type flattenedField struct {
 
 func flattenedFields(v reflect.Value, ptag *Tag) (out []flattenedField, err error) {
 	v = reflect.Indirect(v)
+	if v.Kind() != reflect.Struct {
+		return out, nil
+	}
 	for i := 0; i < v.NumField(); i++ {
 		ft := v.Type().Field(i)
 		fv := v.Field(i)

--- a/context.go
+++ b/context.go
@@ -883,7 +883,7 @@ func checkMissingChildren(node *Node) error {
 	if len(missing) == 1 {
 		return fmt.Errorf("expected %s", missing[0])
 	}
-	return fmt.Errorf("expected one of %s", strings.Join(missing, ",  "))
+	return fmt.Errorf("expected one of %s", strings.Join(missing, ", "))
 }
 
 // If we're missing any positionals and they're required, return an error.

--- a/options.go
+++ b/options.go
@@ -89,6 +89,10 @@ type dynamicCommand struct {
 // "tags" is a list of extra tag strings to parse, in the form <key>:"<value>".
 func DynamicCommand(name, help, group string, cmd interface{}, tags ...string) Option {
 	return OptionFunc(func(k *Kong) error {
+		if run := getMethod(reflect.Indirect(reflect.ValueOf(cmd)), "Run"); !run.IsValid() {
+			return fmt.Errorf("kong: DynamicCommand %q must be a type with a 'Run' method; got %T", name, cmd)
+		}
+
 		k.dynamicCommands = append(k.dynamicCommands, &dynamicCommand{
 			name:  name,
 			help:  help,


### PR DESCRIPTION
This small MR allows using the func-to-interface trick to implement a command (see commandFunc in kong_test.go).

This is useful e.g. for commands that have no flags or arguments of their own, but instead receive all required information via bound  parameters.

:question: we could (but don't need to) also provide a `CommandFunc` type, analogous to `http.HandlerFunc`.