### PR TITLE
Fix reference to non-existent function in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,7 +733,7 @@ All builtin Go types (as well as a bunch of useful stdlib types like `time.Time`
 The default help output is usually sufficient, but if not there are two solutions.
 
 1. Use `ConfigureHelp(HelpOptions)` to configure how help is formatted (see [HelpOptions](https://godoc.org/github.com/alecthomas/kong#HelpOptions) for details).
-2. Custom help can be wired into Kong via the `Help(HelpFunc)` option. The `HelpFunc` is passed a `Context`, which contains the parsed context for the current command-line. See the implementation of `PrintHelp` for an example.
+2. Custom help can be wired into Kong via the `Help(HelpFunc)` option. The `HelpFunc` is passed a `Context`, which contains the parsed context for the current command-line. See the implementation of `DefaultHelpPrinter` for an example.
 3. Use `ValueFormatter(HelpValueFormatter)` if you want to just customize the help text that is accompanied by flags and arguments.
 4. Use `Groups([]Group)` if you want to customize group titles or add a header.
 


### PR DESCRIPTION
The README documentation for `kong.Help` refers to a non-existent function, which I think was previously renamed. This fixes it.