### PR TITLE
Fix broken anchor link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,7 +739,7 @@ The default help output is usually sufficient, but if not there are two solution
 
 ### `Bind(...)` - bind values for callback hooks and Run() methods
 
-See the [section on hooks](#hooks-beforeresolve-beforeapply-afterapply-and-the-bind-option) for details.
+See the [section on hooks](#hooks-beforereset-beforeresolve-beforeapply-afterapply-and-the-bind-option) for details.
 
 ### Other options
 


### PR DESCRIPTION
Hi, maintainer-san 👋🏽
Thank you so much for developing such a great package!

I found a broken anchor link in the document and fixed it.
You can check it works the README in [this branch](https://github.com/ebi-yade/kong/tree/fix/update-readme).