### PR TITLE
fix(Context.Run): Don't panic on unselected root node

### DIFF
--- a/context.go
+++ b/context.go
@@ -827,7 +827,9 @@ func (c *Context) Run(binds ...any) (err error) {
 			if method.IsValid() {
 				node = selected
 			}
-		} else {
+		}
+
+		if node == nil {
 			return fmt.Errorf("no command selected")
 		}
 	}

--- a/kong_test.go
+++ b/kong_test.go
@@ -2495,3 +2495,16 @@ func TestPrefixXorIssue343(t *testing.T) {
 	_, err = kctx.Parse([]string{"--source-password-file=foo", "--source-password=bar"})
 	assert.Error(t, err)
 }
+
+func TestIssue483EmptyRootNodeNoRun(t *testing.T) {
+	var emptyCLI struct{}
+	parser, err := kong.New(&emptyCLI)
+	assert.NoError(t, err)
+
+	kctx, err := parser.Parse([]string{})
+	assert.NoError(t, err)
+
+	err = kctx.Run()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no command selected")
+}


### PR DESCRIPTION
Fixes bug introduced in 2544d3f00855f6857cf121ce04608296b5858e4a.

That commit refactored control flow slightly and missed a case
where the selected node is an application node but it does not
have a Run method.

The fix was straightforward:
Treat the "if application node" code path as a possible way to fill
`node`, and check it again afterwards.

Resolves #483
