### PR TITLE
hooks: Recursively search embedded fields for methods

### DIFF
--- a/kong_test.go
+++ b/kong_test.go
@@ -2405,6 +2405,8 @@ func TestProviderMethods(t *testing.T) {
 }
 
 type EmbeddedCallback struct {
+	Nested NestedCallback `embed:""`
+
 	Embedded bool
 }
 
@@ -2414,11 +2416,22 @@ func (e *EmbeddedCallback) AfterApply() error {
 }
 
 type taggedEmbeddedCallback struct {
+	NestedCallback
+
 	Tagged bool
 }
 
 func (e *taggedEmbeddedCallback) AfterApply() error {
 	e.Tagged = true
+	return nil
+}
+
+type NestedCallback struct {
+	nested bool
+}
+
+func (n *NestedCallback) AfterApply() error {
+	n.nested = true
 	return nil
 }
 
@@ -2441,9 +2454,15 @@ func TestEmbeddedCallbacks(t *testing.T) {
 	expected := &EmbeddedRoot{
 		EmbeddedCallback: EmbeddedCallback{
 			Embedded: true,
+			Nested: NestedCallback{
+				nested: true,
+			},
 		},
 		Tagged: taggedEmbeddedCallback{
 			Tagged: true,
+			NestedCallback: NestedCallback{
+				nested: true,
+			},
 		},
 		Root: true,
 	}


### PR DESCRIPTION
Follow up to #493 and 840220c

Kong currently supports hooks on embedded fields of a parsed node,
but only at the first level of embedding:

```
type mainCmd struct {
    FooOptions
}

type FooOptions struct {
    BarOptions
}

func (f *FooOptions) BeforeApply() error {
    // this will be called
}

type BarOptions struct {
}

func (b *BarOptions) BeforeApply() error {
    // this will not be called
}
```

This change adds support for hooks to be defined
on embedded fields of embedded fields so that the above
example would work as expected.

Per #493, the definition of "embedded" field is adjusted to mean:

- Any anonymous (Go-embedded) field that is exported
- Any non-anonymous field that is tagged with `embed:""`

*Testing*:
Includes a test case for embedding an anonymous field in an `embed:""`
and an `embed:""` field in an anonymous field.
