### PR TITLE
feat: Placeholder string interpolation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,8 +620,8 @@ also supports dynamically adding commands via `kong.DynamicCommand()`.
 
 ## Variable interpolation
 
-Kong supports limited variable interpolation into help strings, enum lists and
-default values.
+Kong supports limited variable interpolation into help strings, placeholder strings,
+enum lists and default values.
 
 Variables are in the form:
 

--- a/kong.go
+++ b/kong.go
@@ -270,6 +270,11 @@ func (k *Kong) interpolateValue(value *Value, vars Vars) (err error) {
 		if len(value.Flag.Envs) != 0 {
 			updatedVars["env"] = value.Flag.Envs[0]
 		}
+
+		value.Flag.PlaceHolder, err = interpolate(value.Flag.PlaceHolder, vars, updatedVars)
+		if err != nil {
+			return fmt.Errorf("placeholder value for %s: %s", value.Summary(), err)
+		}
 	}
 	value.Help, err = interpolate(value.Help, vars, updatedVars)
 	if err != nil {

--- a/kong_test.go
+++ b/kong_test.go
@@ -766,8 +766,8 @@ func TestPassesThroughOriginalCommandError(t *testing.T) {
 
 func TestInterpolationIntoModel(t *testing.T) {
 	var cli struct {
-		Flag    string `default:"${default_value}" help:"Help, I need ${somebody}" enum:"${enum}"`
-		EnumRef string `enum:"a,b" required:"" help:"One of ${enum}"`
+		Flag    string `default:"${default_value}" help:"Help, I need ${somebody}" enum:"${enum}" placeholder:"${enum}"`
+		EnumRef string `enum:"a,b" required:"" help:"One of ${enum}" placeholder:"${enum}"`
 		EnvRef  string `env:"${env}" help:"God ${env}"`
 	}
 	_, err := kong.New(&cli)
@@ -787,7 +787,9 @@ func TestInterpolationIntoModel(t *testing.T) {
 	assert.Equal(t, "Help, I need chickens!", flag.Help)
 	assert.Equal(t, map[string]bool{"a": true, "b": true, "c": true, "d": true}, flag.EnumMap())
 	assert.Equal(t, []string{"a", "b", "c", "d"}, flag.EnumSlice())
+	assert.Equal(t, "a,b,c,d", flag.PlaceHolder)
 	assert.Equal(t, "One of a,b", flag2.Help)
+	assert.Equal(t, "a,b", flag2.PlaceHolder)
 	assert.Equal(t, []string{"SAVE_THE_QUEEN"}, flag3.Envs)
 	assert.Equal(t, "God SAVE_THE_QUEEN", flag3.Help)
 }


### PR DESCRIPTION
Add support string interpolation in placeholder values.

Some tools like to place the supported enum values in the placeholder string. So, it's a tad annoying being able fill in the `enum` value from vars but not the `placeholder` value.