### PR TITLE
feat: Allow configuring hooks via Kong's functional options

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,10 +308,16 @@ func main() {
 
 ## Hooks: BeforeReset(), BeforeResolve(), BeforeApply(), AfterApply()
 
-If a node in the CLI, or any of its embedded fields, has a `BeforeReset(...) error`, `BeforeResolve
-(...) error`, `BeforeApply(...) error` and/or `AfterApply(...) error` method, those
-methods will be called before values are reset, before validation/assignment,
-and after validation/assignment, respectively.
+If a node in the CLI, or any of its embedded fields, implements a `BeforeReset(...) error`, `BeforeResolve
+(...) error`, `BeforeApply(...) error` and/or `AfterApply(...) error` method, those will be called as Kong
+resets, resolves, validates, and assigns values to the node.
+
+| Hook            | Description                                                                                                 |
+| --------------- | ----------------------------------------------------------------------------------------------------------- |
+| `BeforeReset`   | Invoked before values are reset to their defaults (as defined by the grammar) or to zero values             |
+| `BeforeResolve` | Invoked before resolvers are applied to a node                                                              |
+| `BeforeApply`   | Invoked before the traced command line arguments are applied to the grammar                                 |
+| `AfterApply`    | Invoked after command line arguments are applied to the grammar **and validated**`                          |
 
 The `--help` flag is implemented with a `BeforeReset` hook.
 
@@ -339,6 +345,10 @@ func main() {
   // ...
 }
 ```
+
+It's also possible to register these hooks with the functional options
+`kong.WithBeforeReset`, `kong.WithBeforeResolve`, `kong.WithBeforeApply`, and
+`kong.WithAfterApply`.
 
 ##  The Bind() option
 

--- a/hooks.go
+++ b/hooks.go
@@ -1,5 +1,11 @@
 package kong
 
+// BeforeReset is a documentation-only interface describing hooks that run before defaults values are applied.
+type BeforeReset interface {
+	// This is not the correct signature - see README for details.
+	BeforeReset(args ...any) error
+}
+
 // BeforeResolve is a documentation-only interface describing hooks that run before resolvers are applied.
 type BeforeResolve interface {
 	// This is not the correct signature - see README for details.

--- a/options.go
+++ b/options.go
@@ -123,6 +123,40 @@ func PostBuild(fn func(*Kong) error) Option {
 	})
 }
 
+// WithBeforeReset registers a hook to run before fields values are reset to their defaults
+// (as specified in the grammar) or to zero values.
+func WithBeforeReset(fn any) Option {
+	return withHook("BeforeReset", fn)
+}
+
+// WithBeforeResolve registers a hook to run before resolvers are applied.
+func WithBeforeResolve(fn any) Option {
+	return withHook("BeforeResolve", fn)
+}
+
+// WithBeforeApply registers a hook to run before command line arguments are applied to the grammar.
+func WithBeforeApply(fn any) Option {
+	return withHook("BeforeApply", fn)
+}
+
+// WithAfterApply registers a hook to run after values are applied to the grammar and validated.
+func WithAfterApply(fn any) Option {
+	return withHook("AfterApply", fn)
+}
+
+// withHook registers a named hook.
+func withHook(name string, fn any) Option {
+	value := reflect.ValueOf(fn)
+	if value.Kind() != reflect.Func {
+		panic(fmt.Errorf("expected function, got %s", value.Type()))
+	}
+
+	return OptionFunc(func(k *Kong) error {
+		k.hooks[name] = append(k.hooks[name], value)
+		return nil
+	})
+}
+
 // Name overrides the application name.
 func Name(name string) Option {
 	return PostBuild(func(k *Kong) error {


### PR DESCRIPTION
Lets you pass `kong.WithBeforeApply` along with a function that supports dynamic bindings to register a `BeforeApply` hook without tying it directly to a node in the schema.

Also updates the README.md to [list a table of hooks with their meanings](https://github.com/boblail/kong/tree/lail/register-hooks-via-Options?tab=readme-ov-file#hooks-beforereset-beforeresolve-beforeapply-afterapply).

