### PR TITLE
Call functions via context

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -171,7 +171,7 @@ func getMethods(value reflect.Value, name string) (methods []reflect.Value) {
 	return
 }
 
-func callFunction(f reflect.Value, bindings bindings) error {
+func callAnyFunctionErr(f reflect.Value, bindings bindings) error {
 	if f.Kind() != reflect.Func {
 		return fmt.Errorf("expected function, got %s", f.Type())
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -38,7 +38,7 @@ func TestBindTo(t *testing.T) {
 
 	p, err := New(&cli, BindTo(impl("foo"), (*iface)(nil)))
 	assert.NoError(t, err)
-	err = callFunction(reflect.ValueOf(method), p.bindings)
+	err = callAnyFunctionErr(reflect.ValueOf(method), p.bindings)
 	assert.NoError(t, err)
 	assert.Equal(t, "foo", saw)
 }
@@ -58,7 +58,7 @@ func TestInvalidCallback(t *testing.T) {
 
 	p, err := New(&cli, BindTo(impl("foo"), (*iface)(nil)))
 	assert.NoError(t, err)
-	err = callFunction(reflect.ValueOf(method), p.bindings)
+	err = callAnyFunctionErr(reflect.ValueOf(method), p.bindings)
 	assert.EqualError(t, err, `return value of func(kong.iface) string must implement "error"`)
 }
 
@@ -83,7 +83,7 @@ func TestCallbackCustomError(t *testing.T) {
 
 	p, err := New(&cli, BindTo(impl("foo"), (*iface)(nil)))
 	assert.NoError(t, err)
-	err = callFunction(reflect.ValueOf(method), p.bindings)
+	err = callAnyFunctionErr(reflect.ValueOf(method), p.bindings)
 	assert.NoError(t, err)
 	assert.Equal(t, "foo", saw)
 }
@@ -180,6 +180,6 @@ func TestCallbackNonPointerError(t *testing.T) {
 
 	p, err := New(&cli)
 	assert.NoError(t, err)
-	err = callFunction(reflect.ValueOf(method), p.bindings)
+	err = callAnyFunctionErr(reflect.ValueOf(method), p.bindings)
 	assert.EqualError(t, err, "ERROR: failed")
 }


### PR DESCRIPTION
Logic changes:
1. applyHookToDefaultFlags merge bindings from context
Motivation: same as applyHook

2. fixed order in binding (Kong bindings, Context bindings, Call bindings, Context) (see cloneBindings)
Motivation: consistency in different contexts