### PR TITLE
Supporting Nested Subcommands with the Run Method

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -1,0 +1,57 @@
+package kong
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type Runner struct {
+	Context *Context
+	Node    *Node
+	Next    *Runner
+
+	method reflect.Value
+}
+
+func (e *Runner) prepareBindings(binds ...any) (bindings, error) {
+	resultBindings := e.Context.Kong.bindings.clone().merge(e.Context.bindings)
+	for p := e.Node; p != nil; p = p.Parent {
+		resultBindings = resultBindings.add(p.Target.Addr().Interface())
+		// Try value and pointer to value.
+		for _, p := range []reflect.Value{p.Target, p.Target.Addr()} {
+			t := p.Type()
+			for i := 0; i < p.NumMethod(); i++ {
+				methodt := t.Method(i)
+				if strings.HasPrefix(methodt.Name, "Provide") {
+					method := p.Method(i)
+					if err := resultBindings.addProvider(method.Interface(), false /* singleton */); err != nil {
+						return nil, fmt.Errorf("%s.%s: %w", t.Name(), methodt.Name, err)
+					}
+				}
+			}
+		}
+	}
+
+	resultBindings.add(binds...)
+	resultBindings.add(e.Context)
+	resultBindings.add(e)
+
+	return resultBindings, nil
+}
+
+func (e *Runner) runCurrent(binds ...any) (err error) {
+	resultBindings, err := e.prepareBindings(binds...)
+	if err != nil {
+		return err
+	}
+	return callFunction(e.method, resultBindings)
+}
+
+func (e *Runner) RunNext(binds ...any) (err error) {
+	if e == nil || e.Next == nil {
+		return errors.New("no next executor")
+	}
+	return e.Next.runCurrent(binds...)
+}


### PR DESCRIPTION
**Description of Issues:**

1. **Context.Run Always Called from Leaf to Root:**  
   Currently, `Context.Run` is unconditionally called from the leaf up to the root of the tree. Reversing this behavior might make more sense, but it is still very hard to use.  
   *Location:* [context.go:845](https://github.com/alecthomas/kong/blob/master/context.go#L845)

2. **Context.RunNode:**  
   The usage pattern is unclear, and when used in conjunction with `Visit`, it was not possible to create an adequate solution.

3. **Fixed Provide Bug:**  
   It is assumed that the expected behavior was “children receive `Provide` from themselves and their parents” – [context.go:822](https://github.com/alecthomas/kong/blob/master/context.go#L822). In reality, due to [this line in context.go:821](https://github.com/alecthomas/kong/blob/master/context.go#L821), everything degenerates to the behavior where “everyone receives `Provide` from everyone”.

---

**Corrections:**

1. `Context.RunNode` has been completely removed.
2. The `Context.Run` method now always calls the `Run` method of the node that is closest to the root.
3. For subsequent calls to the `Run` method of nested commands, it is suggested to use `Runner.RunNext(...binds)`.
