### PR TITLE
Add AfterRun hook to README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,18 +306,19 @@ func main() {
 
 ```
 
-## Hooks: BeforeReset(), BeforeResolve(), BeforeApply(), AfterApply()
+## Hooks: BeforeReset(), BeforeResolve(), BeforeApply(), AfterApply(), AfterRun()
 
 If a node in the CLI, or any of its embedded fields, implements a `BeforeReset(...) error`, `BeforeResolve
-(...) error`, `BeforeApply(...) error` and/or `AfterApply(...) error` method, those will be called as Kong
-resets, resolves, validates, and assigns values to the node.
+(...) error`, `BeforeApply(...) error`, `AfterApply(...) error`, and/or `AfterRun(...) error` method, those 
+will be called as Kong resets, resolves, validates, and assigns values to the node.
 
 | Hook            | Description                                                                                                 |
 | --------------- | ----------------------------------------------------------------------------------------------------------- |
 | `BeforeReset`   | Invoked before values are reset to their defaults (as defined by the grammar) or to zero values             |
 | `BeforeResolve` | Invoked before resolvers are applied to a node                                                              |
 | `BeforeApply`   | Invoked before the traced command line arguments are applied to the grammar                                 |
-| `AfterApply`    | Invoked after command line arguments are applied to the grammar **and validated**`                          |
+| `AfterApply`    | Invoked after command line arguments are applied to the grammar **and validated**                           |
+| `AfterRun`      | Invoked after `Run()` returns. Will not be called if `os.Exit()` is manually called.                        |
 
 The `--help` flag is implemented with a `BeforeReset` hook.
 


### PR DESCRIPTION
I always forget that `AfterRun` exists so I finally put a docs PR in for it.