### PR TITLE
feat: expose ValueFormatter option through HelpOptions for custom HelpPrinters

### DIFF
--- a/context.go
+++ b/context.go
@@ -883,6 +883,11 @@ func (c *Context) Run(binds ...any) (err error) {
 func (c *Context) PrintUsage(summary bool) error {
 	options := c.helpOptions
 	options.Summary = summary
+	return c.printHelp(options)
+}
+
+func (c *Context) printHelp(options HelpOptions) error {
+	options.ValueFormatter = c.Kong.helpFormatter
 	return c.help(options, c)
 }
 

--- a/kong.go
+++ b/kong.go
@@ -472,7 +472,7 @@ func (k *Kong) FatalIfErrorf(err error, args ...any) {
 	if errors.As(err, &parseErr) {
 		switch k.usageOnError {
 		case fullUsage:
-			_ = k.help(k.helpOptions, parseErr.Context)
+			_ = parseErr.Context.printHelp(k.helpOptions)
 			fmt.Fprintln(k.Stdout)
 		case shortUsage:
 			_ = k.shortHelp(k.helpOptions, parseErr.Context)


### PR DESCRIPTION
## Motivation

When implementing custom `HelpPrinter` functions, there was no way to access the configured `HelpValueFormatter` (set via `kong.ValueFormatter()`). This meant custom help printers couldn't format flag and argument values consistently with the rest of Kong's help system.

The `ValueFormatter` is used to customise how help text is displayed for flags and positional arguments (e.g., adding environment variable suffixes, custom formatting, etc.). While this was available to Kong's built-in help printer, custom help printers had no access to it.

## Changes

This PR exposes the `HelpValueFormatter` through the `HelpOptions` struct that is passed to custom `HelpPrinter` functions, enabling custom help implementations to format values consistently with the application's configuration.

Key changes:
- Added `ValueFormatter HelpValueFormatter` field to `HelpOptions` struct
- Refactored `Context.PrintUsage()` to use a new internal `Context.printHelp()` method that ensures ValueFormatter is always set in `HelpOptions` before calling the help printer
  - Updated all `help` invocation points to use the new pattern
- Refactored usages of `helpWriter.helpFormatter` to use `helpWriter.HelpOptions.ValueFormatter` instead and removed the old field

## Implementation Details

The refactoring ensures that whenever a help printer is called (whether through `--help`, `ctx.PrintUsage()`, or error handling), the `ValueFormatter` is automatically populated from kong.helpFormatter into the HelpOptions.

## Backward Compatibility

This change is fully backward compatible:
- Existing custom help printers continue to work without modification
- The new field is simply available if custom help printers want to use it
- No breaking changes to any public APIs
