### PR TITLE
Duplicate Flags: implement a new "strict mode"

### DIFF
--- a/kong.go
+++ b/kong.go
@@ -56,9 +56,10 @@ type Kong struct {
 	registry     *Registry
 	ignoreFields []*regexp.Regexp
 
-	noDefaultHelp   bool
-	allowHyphenated bool
-	usageOnError    usageOnError
+	noDefaultHelp        bool
+	allowHyphenated      bool
+	strictDuplicateFlags bool
+	usageOnError         usageOnError
 	help            HelpPrinter
 	shortHelp       HelpPrinter
 	helpFormatter   HelpValueFormatter

--- a/options.go
+++ b/options.go
@@ -65,6 +65,20 @@ func WithHyphenPrefixedParameters(enable bool) Option {
 	})
 }
 
+// StrictDuplicateFlags enables strict duplicate flag checking.
+//
+// When enabled, Kong will return an error if a flag is provided multiple times.
+// By default Kong silently overwrites earlier flag values with later ones.
+//
+// Note: Slice/array flags are exempt from this check as they legitimately
+// accept multiple values via repeated flags.
+func StrictDuplicateFlags() Option {
+	return OptionFunc(func(k *Kong) error {
+		k.strictDuplicateFlags = true
+		return nil
+	})
+}
+
 type embedded struct {
 	strct any
 	tags  []string


### PR DESCRIPTION
Add an option `StrictDuplicateFlags` to return an error when a flag is passed twice.

Fixes #441