### PR TITLE
fix: Avoid printing invalid sep

### DIFF
--- a/mapper.go
+++ b/mapper.go
@@ -541,8 +541,12 @@ func sliceDecoder(r *Registry) MapperFunc {
 		if ctx.Value.Flag != nil {
 			t := ctx.Scan.Pop()
 			// If decoding a flag, we need a value.
+			tail := ""
+			if sep != -1 {
+				tail += string(sep) + "..."
+			}
 			if t.IsEOL() {
-				return fmt.Errorf("missing value, expecting \"<arg>%c...\"", sep)
+				return fmt.Errorf("missing value, expecting \"<arg>%s\"", tail)
 			}
 			switch v := t.Value.(type) {
 			case string:


### PR DESCRIPTION
When we print the placeholder, [we were doing a check](https://github.com/alecthomas/kong/blob/73db2e86a5dee444a2089c62beff8703c82467b4/model.go#L438-L441) to ensure that `Sep` is not `-1`. However, this wasn't being done in the error message, resulting in output like:

<img width="781" height="48" alt="image" src="https://github.com/user-attachments/assets/e40e795b-027e-4e41-9b0b-3924deb269e1" />
