### PR TITLE
fix: Allow the root node to define `Help()`

### DIFF
--- a/build.go
+++ b/build.go
@@ -32,6 +32,9 @@ func build(k *Kong, ast any) (app *Application, err error) {
 	if len(node.Positional) > 0 && len(node.Children) > 0 {
 		return nil, fmt.Errorf("can't mix positional arguments and branching arguments on %T", ast)
 	}
+	if provider, ok := v.Interface().(HelpProvider); ok {
+		node.Detail = provider.Help()
+	}
 	app.Node = node
 	app.Node.Flags = append(extraFlags, app.Node.Flags...)
 	app.Tag = newEmptyTag()

--- a/help_test.go
+++ b/help_test.go
@@ -863,3 +863,43 @@ test: error: missing flags: --flag=STRING
 	assert.Equal(t, expected, w.String())
 	assert.Equal(t, 80, exitCode)
 }
+
+type rootHelpProvider struct {
+	Flag string `help:"A flag."`
+}
+
+func (rootHelpProvider) Help() string {
+	return `Detailed help provided by the root HelpProvider.`
+}
+
+func TestHelpProviderOnRoot(t *testing.T) {
+	var cli rootHelpProvider
+	w := bytes.NewBuffer(nil)
+	exited := false
+	app := mustNew(t, &cli,
+		kong.Name("test-app"),
+		kong.Description("A test app."),
+		kong.Writers(w, w),
+		kong.Exit(func(int) {
+			exited = true
+			panic(true)
+		}),
+	)
+	panicsTrue(t, func() {
+		_, err := app.Parse([]string{"--help"})
+		assert.NoError(t, err)
+	})
+	assert.True(t, exited)
+	expected := `Usage: test-app [flags]
+
+A test app.
+
+Detailed help provided by the root HelpProvider.
+
+Flags:
+  -h, --help           Show context-sensitive help.
+      --flag=STRING    A flag.
+`
+	t.Log(w.String())
+	assert.Equal(t, expected, w.String())
+}


### PR DESCRIPTION
so you can use this pattern with a simple command line application