### PR TITLE
fix: interpolate ${env} in help text for positional arguments

### DIFF
--- a/issue556_test.go
+++ b/issue556_test.go
@@ -1,0 +1,34 @@
+package kong_test
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+)
+
+func TestIssue556_PositionalArgEnvInHelp(t *testing.T) {
+	var cli struct {
+		Foo string `arg:"" help:"Foo (${env})" env:"FOO"`
+	}
+	p := mustNew(t, &cli)
+	// Verify ${env} was interpolated to the env var name.
+	assert.Equal(t, "Foo (FOO)", p.Model.Positional[0].Help)
+}
+
+func TestPositionalArgEnvInHelp_NoEnv(t *testing.T) {
+	var cli struct {
+		Foo string `arg:"" help:"Foo (${env})"`
+	}
+	// When no env tag is set, ${env} should interpolate to empty string.
+	p := mustNew(t, &cli)
+	assert.Equal(t, "Foo ()", p.Model.Positional[0].Help)
+}
+
+func TestPositionalArgEnvInHelp_MultipleEnvs(t *testing.T) {
+	var cli struct {
+		Foo string `arg:"" help:"Foo (${env})" env:"FOO,BAR"`
+	}
+	// With multiple env vars, ${env} should use the first one.
+	p := mustNew(t, &cli)
+	assert.Equal(t, "Foo (FOO)", p.Model.Positional[0].Help)
+}

--- a/kong.go
+++ b/kong.go
@@ -282,8 +282,17 @@ func (k *Kong) interpolateValue(value *Value, vars Vars) (err error) {
 		if err != nil {
 			return fmt.Errorf("placeholder value for %s: %s", value.Summary(), err)
 		}
+	} else {
+		updatedVars["env"] = ""
+		if len(value.Tag.Envs) != 0 {
+			updatedVars["env"] = value.Tag.Envs[0]
+		}
 	}
-	value.Help, err = interpolate(value.Help, vars, updatedVars)
+	// Merge updatedVars into vars explicitly because interpolate() skips
+	// the merge when all updatedVars values equal the zero value of missing
+	// map keys (e.g. env="").
+	vars = vars.CloneWith(updatedVars)
+	value.Help, err = interpolate(value.Help, vars, nil)
 	if err != nil {
 		return fmt.Errorf("help for %s: %s", value.Summary(), err)
 	}


### PR DESCRIPTION
Fixes #556.

**Problem:** Using `${env}` in the help text of a positional argument (`arg:""`) panics with "undefined variable ${env}", while it works fine for flags.

```go
// panics
var cli struct {
    Foo string `arg:"" help:"Foo (${env})" env:"FOO"`
}
```

**Cause:** `interpolateValue()` only populated the `env` variable in `updatedVars` when `value.Flag != nil`. Positional arguments have `value.Flag == nil`, so `env` was never set.

**Fix:** Populate `env` from `value.Tag.Envs` for positional arguments. Also merge `updatedVars` into `vars` explicitly before interpolating help, since `interpolate()` skips the merge when values equal missing map keys (both `""`).

**After:** `${env}` resolves to the first env var name for positional args (or `""` if no env tag), matching flag behavior.

All existing tests pass; added regression tests for the three cases (env set, env unset, multiple envs).