### PR TITLE
feat: add NoAppDescFormat option to HelpOptions

### DIFF
--- a/_examples/asciilogo/main.go
+++ b/_examples/asciilogo/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alecthomas/kong"
+)
+
+const logo = `
+#   #   ###    #   #    ###
+#  #   #   #   ##  #   #
+###    #   #   # # #   #  ##
+#  #   #   #   #  ##   #   #
+#   #   ###    #   #    ###`
+
+var cli struct {
+	Quiet bool `help:"Suppress non-error output."`
+
+	Say struct {
+		Text string `arg:"" help:"Text to echo."`
+	} `cmd:"" help:"Print text to stdout."`
+}
+
+func main() {
+	ctx := kong.Parse(&cli,
+		kong.Name("kong-logo"),
+		kong.Description(strings.TrimSpace(logo)+"\n\n"+
+			"Simple example which shows how to disable formatting of\n"+
+			"the description text, to display ASCII art as-is."),
+		kong.UsageOnError(),
+		kong.ConfigureHelp(kong.HelpOptions{
+			NoAppDescFormat: true,
+		}),
+	)
+	switch ctx.Command() {
+	case "say <text>":
+		if !cli.Quiet {
+			fmt.Println(cli.Say.Text)
+		}
+	}
+}

--- a/help.go
+++ b/help.go
@@ -61,6 +61,10 @@ type HelpOptions struct {
 
 	// ValueFormatter is used to format the help text of flags and positional arguments.
 	ValueFormatter HelpValueFormatter
+
+	// NoAppDescFormat skips all formatting of app description text (wrapping, paragraph
+	// reflow, newline merging, etc).
+	NoAppDescFormat bool
 }
 
 // Apply options to Kong as a configuration option.
@@ -162,10 +166,16 @@ func printCommand(w *helpWriter, app *Application, cmd *Command) {
 	}
 }
 
-func printNodeDetail(w *helpWriter, node *Node, hide bool) {
+func printNodeDetail(w *helpWriter, node *Node, hide bool) { //nolint:gocyclo
 	if node.Help != "" {
 		w.Print("")
-		w.Wrap(node.Help)
+		if w.NoAppDescFormat && node.Parent == nil {
+			for _, line := range strings.Split(node.Help, "\n") {
+				w.Print(line)
+			}
+		} else {
+			w.Wrap(node.Help)
+		}
 	}
 	if w.Summary {
 		return

--- a/help_test.go
+++ b/help_test.go
@@ -872,6 +872,76 @@ func (rootHelpProvider) Help() string {
 	return `Detailed help provided by the root HelpProvider.`
 }
 
+func TestHelpNoAppDescFormat(t *testing.T) {
+	// Space-separated text wraps with doc.ToText under a narrow bound; a single
+	// unbroken run of characters may not be split.
+	longLine := strings.TrimRight(strings.Repeat("alpha ", 18), " ")
+	var cli struct {
+		Sub struct{} `cmd help:"row one\nrow two"`
+	}
+
+	w := bytes.NewBuffer(nil)
+	exited := false
+	app := mustNew(t, &cli,
+		kong.Name("no-sum-app"),
+		kong.Description("intro\n"+longLine),
+		kong.HelpOptions{
+			NoAppDescFormat: true,
+			WrapUpperBound:  50,
+		},
+		kong.Writers(w, w),
+		kong.Exit(func(int) {
+			exited = true
+			panic(true)
+		}),
+	)
+
+	panicsTrue(t, func() {
+		_, err := app.Parse([]string{"--help"})
+		assert.NoError(t, err)
+	})
+	assert.True(t, exited)
+	out := w.String()
+
+	// App description should preserve newlines and not wrap the long line to fit WrapUpperBound.
+	assert.True(t, strings.Contains(out, longLine), "expected full unwrapped description line in output:\n%s", out)
+	lines := strings.Split(out, "\n")
+	var sawIntro bool
+	for _, line := range lines {
+		if line == "intro" {
+			sawIntro = true
+			break
+		}
+	}
+	assert.True(t, sawIntro, "expected unformatted intro line (no wrap indentation); got:\n%s", out)
+
+	// Subcommand summaries still use Wrap; multi-line help tags are reflowed to spaces.
+	assert.True(t, strings.Contains(out, "row one row two"), out)
+
+	// Control: default formatting wraps the long description so it is not one contiguous 60-char line.
+	wControl := bytes.NewBuffer(nil)
+	exitedControl := false
+	appControl := mustNew(t, &cli,
+		kong.Name("no-sum-app"),
+		kong.Description("intro\n"+longLine),
+		kong.HelpOptions{
+			WrapUpperBound: 50,
+		},
+		kong.Writers(wControl, wControl),
+		kong.Exit(func(int) {
+			exitedControl = true
+			panic(true)
+		}),
+	)
+	panicsTrue(t, func() {
+		_, err := appControl.Parse([]string{"--help"})
+		assert.NoError(t, err)
+	})
+	assert.True(t, exitedControl)
+	controlOut := wControl.String()
+	assert.False(t, strings.Contains(controlOut, longLine), "wrapped output should not contain the full description line intact:\n%s", controlOut)
+}
+
 func TestHelpProviderOnRoot(t *testing.T) {
 	var cli rootHelpProvider
 	w := bytes.NewBuffer(nil)


### PR DESCRIPTION
### Changes in this PR

This PR allows disabling of the go-doc style post-processing on command output for app descriptions, through a new `HelpOptions.NoAppDescFormat` boolean. I decided to only cover the top-level app description, as handling in other places with sub-commands, which may be rendered in other places (like the sub-command list, when called from the root), would potentially break formatting more drastically in unexpected ways.

I've also added a simple ASCII logo example.

### Associated Issues

- closes #376