### PR TITLE
fix: interpolate ${env} in help for positional arguments

### DIFF
--- a/kong.go
+++ b/kong.go
@@ -282,6 +282,16 @@ func (k *Kong) interpolateValue(value *Value, vars Vars) (err error) {
 		if err != nil {
 			return fmt.Errorf("placeholder value for %s: %s", value.Summary(), err)
 		}
+	} else {
+		for i, env := range value.Tag.Envs {
+			if value.Tag.Envs[i], err = interpolate(env, vars, updatedVars); err != nil {
+				return fmt.Errorf("env value for %s: %s", value.Summary(), err)
+			}
+		}
+		updatedVars["env"] = ""
+		if len(value.Tag.Envs) != 0 {
+			updatedVars["env"] = value.Tag.Envs[0]
+		}
 	}
 	value.Help, err = interpolate(value.Help, vars, updatedVars)
 	if err != nil {

--- a/kong_test.go
+++ b/kong_test.go
@@ -864,6 +864,17 @@ func TestIssue244(t *testing.T) {
 	assert.Contains(t, w.String(), `Environment variable: CI_PROJECT_ID`)
 }
 
+func TestEnvInterpolationForPositionalArg(t *testing.T) {
+	var cli struct {
+		Foo string `arg:"" optional:"" env:"FOO" help:"Foo (${env})"`
+	}
+	w := &strings.Builder{}
+	k := mustNew(t, &cli, kong.Exit(func(int) {}), kong.Writers(w, w))
+	_, err := k.Parse([]string{"--help"})
+	assert.NoError(t, err)
+	assert.Contains(t, w.String(), `Foo (FOO)`)
+}
+
 func TestErrorMissingArgs(t *testing.T) {
 	var cli struct {
 		One string `arg:""`


### PR DESCRIPTION
Positional arguments with an `env` tag panicked with "undefined variable ${env}" when their help text referenced `${env}`, because the `env` interpolation variable was only populated for flags. This also interpolates the `Tag.Envs` entries themselves for positional values. Closes #556