### PR TITLE
allow ${env} in the help template of a positional argument

### DIFF
--- a/interpolate.go
+++ b/interpolate.go
@@ -26,7 +26,14 @@ func interpolate(s string, vars Vars, updatedVars map[string]string) (string, er
 		return s, nil
 	}
 	for key, val := range updatedVars {
-		if vars[key] != val {
+		// A missing key in vars looks identical to one mapped to the
+		// zero value, so the cheap `vars[key] != val` check used to
+		// silently drop the updatedVars when both sides were the empty
+		// string. That mattered for positional arguments: ${env} is
+		// updated to "" before help interpolation, but the inner
+		// vars map never carries an "env" entry, so interpolate would
+		// fail with "undefined variable". See #556.
+		if existing, ok := vars[key]; !ok || existing != val {
 			vars = vars.CloneWith(updatedVars)
 			break
 		}

--- a/kong.go
+++ b/kong.go
@@ -282,6 +282,12 @@ func (k *Kong) interpolateValue(value *Value, vars Vars) (err error) {
 		if err != nil {
 			return fmt.Errorf("placeholder value for %s: %s", value.Summary(), err)
 		}
+	} else {
+		// Positional arguments can't have ${env} resolve to anything
+		// real (there's no env tag for positionals), but help is
+		// interpolated for them too, so default it to empty rather
+		// than letting the interpolation error out. See #556.
+		updatedVars["env"] = ""
 	}
 	value.Help, err = interpolate(value.Help, vars, updatedVars)
 	if err != nil {

--- a/kong_test.go
+++ b/kong_test.go
@@ -864,6 +864,17 @@ func TestIssue244(t *testing.T) {
 	assert.Contains(t, w.String(), `Environment variable: CI_PROJECT_ID`)
 }
 
+// Regression for #556. ${env} in a positional argument's help template
+// used to panic with "undefined variable" because the interpolation
+// path for positionals never seeded ${env} the way the flag path did.
+func TestPositionalArgWithEnvInHelp(t *testing.T) {
+	type Config struct {
+		Foo string `arg:"" help:"Foo (${env})"`
+	}
+	_, err := kong.New(&Config{})
+	assert.NoError(t, err)
+}
+
 func TestErrorMissingArgs(t *testing.T) {
 	var cli struct {
 		One string `arg:""`


### PR DESCRIPTION
Fixes #556.

\`interpolateValue\` only seeded \`updatedVars[\"env\"]\` inside the \`value.Flag != nil\` branch, so a positional argument with \`\${env}\` in its help template hit \"undefined variable\" and bubbled through \`FatalIfErrorf\`.

Two changes:
- \`interpolateValue\` now also defaults \`env\` to \`\"\"\` when \`value.Flag\` is nil so help interpolation has a value to read.
- \`interpolate\` forces a \`CloneWith\` when \`updatedVars\` contains a key that's missing from \`vars\`. The previous cheap equality check treated a missing entry and an empty string as the same thing and silently skipped the merge, which is why the seed in step 1 wasn't enough on its own.

Existing flag-side behavior is unchanged.

Added \`TestPositionalArgWithEnvInHelp\` covering the issue's reproducer.