### PR TITLE
fire AfterApply for env-only flags

### DIFF
--- a/kong.go
+++ b/kong.go
@@ -397,7 +397,7 @@ func (k *Kong) getMethods(value reflect.Value, name string) []reflect.Value {
 	)
 }
 
-// Call hook on any unset flags with default values.
+// Call hook on any unset flags with default values or values supplied via env.
 func (k *Kong) applyHookToDefaultFlags(ctx *Context, node *Node, name string) error {
 	if node == nil {
 		return nil
@@ -409,7 +409,15 @@ func (k *Kong) applyHookToDefaultFlags(ctx *Context, node *Node, name string) er
 		}
 		binds := k.bindings.clone().add(ctx).add(node.Vars().CloneWith(k.vars))
 		for _, flag := range node.Flags {
-			if !flag.HasDefault || ctx.values[flag.Value].IsValid() || !flag.Target.IsValid() {
+			// Flags handled here are the ones that won't show up in ctx.Path:
+			// they got their value from the default tag or an env var, both of
+			// which Reset() applies straight to the target without touching the
+			// parse path. Anything actually parsed off argv or set by a resolver
+			// shows up in ctx.values and is covered by the main hook loop.
+			if ctx.values[flag.Value].IsValid() || !flag.Target.IsValid() {
+				continue
+			}
+			if !flag.HasDefault && !atLeastOneEnvSet(flag.Tag.Envs) {
 				continue
 			}
 			for _, method := range getMethods(flag.Target, name) {

--- a/kong_test.go
+++ b/kong_test.go
@@ -2605,6 +2605,33 @@ func TestApplyCalledOnce(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+type envOnlyAfterApply struct {
+	called bool
+}
+
+func (e *envOnlyAfterApply) UnmarshalText(text []byte) error { return nil }
+
+func (e *envOnlyAfterApply) AfterApply() error {
+	e.called = true
+	return nil
+}
+
+// Regression for #596: flags whose value is supplied via env should
+// fire AfterApply just like flags set on the command line or by a
+// resolver. The Reset path that applies env values doesn't add the
+// flag to ctx.Path, so the hook used to be silently skipped.
+func TestAfterApplyFiresForEnvOnlyFlag(t *testing.T) {
+	type CLI struct {
+		Field envOnlyAfterApply `env:"KONG_ENVHOOK_FIELD"`
+	}
+	var cli CLI
+
+	t.Setenv("KONG_ENVHOOK_FIELD", "from-env")
+	_, err := mustNew(t, &cli).Parse(nil)
+	assert.NoError(t, err)
+	assert.True(t, cli.Field.called, "AfterApply should fire for env-only flags")
+}
+
 func TestCustomTypeNoEllipsis(t *testing.T) {
 	type CLI struct {
 		Flag []byte `type:"existingfile"`


### PR DESCRIPTION
Closes #596.

Reset() applies env vars to the target field directly and never adds the flag to ctx.Path, so the main applyHook loop walks past them. applyHookToDefaultFlags was the catch-all for that case, but it only matched flags with a default tag. Flags whose value comes purely from \`env:"…"\` had nowhere to fire from.

Loosen the second pass to also match flags with at least one env var set. ctx.values is still the dedup guard, so anything actually parsed off argv or supplied by a resolver still goes through the main loop and only fires once.

Test added that fails on master and passes with this change.