### PR TITLE
Support the env tag on positional arguments (closes #556)

### DIFF
--- a/kong.go
+++ b/kong.go
@@ -266,18 +266,17 @@ func (k *Kong) interpolateValue(value *Value, vars Vars) (err error) {
 		"default": value.Default,
 		"enum":    value.Enum,
 	}
+	for i, env := range value.Tag.Envs {
+		if value.Tag.Envs[i], err = interpolate(env, vars, updatedVars); err != nil {
+			return fmt.Errorf("env value for %s: %s", value.Summary(), err)
+		}
+	}
+	updatedVars["env"] = ""
+	if len(value.Tag.Envs) != 0 {
+		updatedVars["env"] = value.Tag.Envs[0]
+	}
 	if value.Flag != nil {
-		for i, env := range value.Flag.Envs {
-			if value.Flag.Envs[i], err = interpolate(env, vars, updatedVars); err != nil {
-				return fmt.Errorf("env value for %s: %s", value.Summary(), err)
-			}
-		}
-		value.Tag.Envs = value.Flag.Envs
-		updatedVars["env"] = ""
-		if len(value.Flag.Envs) != 0 {
-			updatedVars["env"] = value.Flag.Envs[0]
-		}
-
+		value.Flag.Envs = value.Tag.Envs
 		value.Flag.PlaceHolder, err = interpolate(value.Flag.PlaceHolder, vars, updatedVars)
 		if err != nil {
 			return fmt.Errorf("placeholder value for %s: %s", value.Summary(), err)

--- a/kong_test.go
+++ b/kong_test.go
@@ -864,6 +864,22 @@ func TestIssue244(t *testing.T) {
 	assert.Contains(t, w.String(), `Environment variable: CI_PROJECT_ID`)
 }
 
+func TestPositionalArgWithEnv(t *testing.T) {
+	type Config struct {
+		Foo string `arg:"" env:"FOO" help:"Foo (${env})"`
+	}
+	// Help template should interpolate ${env} from the env tag (#556).
+	_, err := kong.New(&Config{})
+	assert.NoError(t, err)
+
+	// Value should also fill from the env var when the positional is omitted.
+	t.Setenv("FOO", "from-env")
+	var cli Config
+	_, err = mustNew(t, &cli).Parse(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "from-env", cli.Foo)
+}
+
 func TestErrorMissingArgs(t *testing.T) {
 	var cli struct {
 		One string `arg:""`


### PR DESCRIPTION
Took another swing at this per the feedback on #599.

The previous version just defaulted \${env} to \`\"\"\` for positionals, which (rightly) only papered over the panic. This version actually supports the \`env\` tag on positionals: env-value interpolation runs unconditionally off \`value.Tag.Envs\`, the help template's \`\${env}\` resolves to the first env name, and \`Value.Reset\` already reads \`Tag.Envs\` so an env var fills the positional when it's omitted on argv.

\`TestPositionalArgWithEnv\` covers both halves (help interpolation + env-as-default).

closes #556