### PR TITLE
Fix mixed bare and kong tags

### DIFF
--- a/tag.go
+++ b/tag.go
@@ -166,13 +166,25 @@ func parseTagItems(tagString string, chr tagChars) (map[string][]string, error) 
 	return d, nil
 }
 
-func getTagInfo(tag reflect.StructTag) (string, tagChars) {
-	s, ok := tag.Lookup("kong")
-	if ok {
-		return s, kongChars
+func parseStructTagItems(tag reflect.StructTag) (map[string][]string, error) {
+	items, err := parseTagItems(string(tag), bareChars)
+	if err != nil {
+		return nil, err
 	}
+	delete(items, "kong")
 
-	return string(tag), bareChars
+	kongTag, ok := tag.Lookup("kong")
+	if !ok {
+		return items, nil
+	}
+	kongItems, err := parseTagItems(kongTag, kongChars)
+	if err != nil {
+		return nil, err
+	}
+	for key, value := range kongItems {
+		items[key] = append(value, items[key]...)
+	}
+	return items, nil
 }
 
 func newEmptyTag() *Tag {
@@ -208,14 +220,14 @@ func parseTag(parent reflect.Value, ft reflect.StructField) (*Tag, error) {
 	// First use a [Signature] if present
 	signatureTag, ok := maybeGetSignature(ft.Type)
 	if ok {
-		signatureItems, err := parseTagItems(getTagInfo(signatureTag))
+		signatureItems, err := parseStructTagItems(signatureTag)
 		if err != nil {
 			return nil, err
 		}
 		items = signatureItems
 	}
 	// Next overlay the field's tags.
-	fieldItems, err := parseTagItems(getTagInfo(ft.Tag))
+	fieldItems, err := parseStructTagItems(ft.Tag)
 	if err != nil {
 		return nil, err
 	}

--- a/tag_test.go
+++ b/tag_test.go
@@ -109,6 +109,38 @@ func TestBareTagsWithJsonTag(t *testing.T) {
 	assert.Equal(t, "", cli.Cmd.Arg)
 }
 
+func TestBareAndKongTagsCoexist(t *testing.T) {
+	type Source struct {
+		Name string `required:"" xor:"source" kong:"predictor=session-name"`
+		Pick bool   `required:"" xor:"source"`
+	}
+	type CLI struct {
+		Source `embed:""`
+	}
+
+	cli := &CLI{}
+	p := mustNew(t, cli)
+	_, err := p.Parse(nil)
+	assert.EqualError(t, err, "missing flags: --name=STRING or --pick")
+
+	cli = &CLI{}
+	p = mustNew(t, cli)
+	_, err = p.Parse([]string{"--name=session"})
+	assert.NoError(t, err)
+	assert.Equal(t, "session", cli.Name)
+
+	cli = &CLI{}
+	p = mustNew(t, cli)
+	_, err = p.Parse([]string{"--pick"})
+	assert.NoError(t, err)
+	assert.True(t, cli.Pick)
+
+	cli = &CLI{}
+	p = mustNew(t, cli)
+	_, err = p.Parse([]string{"--name=session", "--pick"})
+	assert.EqualError(t, err, "--name and --pick can't be used together")
+}
+
 func TestManySeps(t *testing.T) {
 	var cli struct {
 		Arg string `arg    optional    default:"hi"`


### PR DESCRIPTION
## Summary

Fixes parsing fields that combine bare tags with a `kong:"..."` tag.

## What changed

- Added regression coverage for an embedded struct that mixes bare `required`/`xor` tags with `kong:"predictor=..."`.
- Parsed bare field tags and `kong` field tags together instead of choosing only one form.
- Preserved `kong:"-"` ignore behavior and existing bare-only / kong-only tag behavior.

## Why

Issue #558 reports that adding `kong:"predictor=session-name"` to a field causes bare tags such as `required:""` and `xor:"..."` to be ignored, which contradicts the README statement that both tag forms can coexist.

## Testing

- `go test ./... -run TestBareAndKongTagsCoexist`
- `go test ./...`

Fixes #558
