### PR TITLE
feat: support xor/and groups for positional arguments

### DIFF
--- a/context.go
+++ b/context.go
@@ -260,7 +260,7 @@ func (c *Context) Validate() error { //nolint: gocyclo
 				return err
 			}
 		}
-		if err := checkMissingFlags(path.Flags); err != nil {
+		if err := checkMissingFlags(path.Flags, path.Positional); err != nil {
 			return err
 		}
 	}
@@ -284,7 +284,7 @@ func (c *Context) Validate() error { //nolint: gocyclo
 	if err := checkMissingPositionals(positionals, node.Positional); err != nil {
 		return err
 	}
-	if err := checkXorDuplicatedAndAndMissing(c.Path); err != nil {
+	if err := checkXorDuplicatedAndAndMissing(c.Path, node); err != nil {
 		return err
 	}
 
@@ -891,13 +891,24 @@ func (c *Context) printHelp(options HelpOptions) error {
 	return c.help(options, c)
 }
 
-func checkMissingFlags(flags []*Flag) error {
+func checkMissingFlags(flags []*Flag, positional *Value) error {
 	xorGroupSet := map[string]bool{}
 	xorGroup := map[string][]string{}
 	andGroupSet := map[string]bool{}
 	andGroup := map[string][]string{}
 	missing := []string{}
 	andGroupRequired := getRequiredAndGroupMap(flags)
+
+	// Check positional arg for xor/and groups.
+	if positional != nil && positional.Set {
+		for _, xor := range positional.Tag.Xor {
+			xorGroupSet[xor] = true
+		}
+		for _, and := range positional.Tag.And {
+			andGroupSet[and] = true
+		}
+	}
+
 	for _, flag := range flags {
 		for _, and := range flag.And {
 			flag.Required = andGroupRequired[and]
@@ -1069,12 +1080,12 @@ func checkPassthroughArg(target reflect.Value) bool {
 	}
 }
 
-func checkXorDuplicatedAndAndMissing(paths []*Path) error {
+func checkXorDuplicatedAndAndMissing(paths []*Path, node *Node) error {
 	errs := []string{}
 	if err := checkXorDuplicates(paths); err != nil {
 		errs = append(errs, err.Error())
 	}
-	if err := checkAndMissing(paths); err != nil {
+	if err := checkAndMissing(paths, node); err != nil {
 		errs = append(errs, err.Error())
 	}
 	if len(errs) > 0 {
@@ -1084,51 +1095,136 @@ func checkXorDuplicatedAndAndMissing(paths []*Path) error {
 }
 
 func checkXorDuplicates(paths []*Path) error {
+	// Group paths by command scope. Root-level paths (App != nil or no flags/positional)
+	// are grouped together. Command-level paths (Parent != nil with flags) get their own group.
+	// Positional paths at root level share the root group.
+	rootGroup := []*Path{}
+	commandGroups := map[*Node][]*Path{}
+	hasRoot := false
 	for _, path := range paths {
-		seen := map[string]*Flag{}
-		for _, flag := range path.Flags {
-			if !flag.Set {
-				continue
+		if path.App != nil || (path.Parent == nil && (len(path.Flags) > 0 || path.Positional != nil)) {
+			rootGroup = append(rootGroup, path)
+			hasRoot = true
+		} else if path.Parent != nil && len(path.Flags) > 0 {
+			commandGroups[path.Parent] = append(commandGroups[path.Parent], path)
+		} else if path.Parent != nil && path.Positional != nil {
+			// Positional args at non-root level: if there's a root group, merge into it
+			// (flat struct case where positional has a different parent pointer)
+			if hasRoot {
+				rootGroup = append(rootGroup, path)
+			} else {
+				commandGroups[path.Parent] = append(commandGroups[path.Parent], path)
 			}
-			for _, xor := range flag.Xor {
-				if seen[xor] != nil {
-					return fmt.Errorf("--%s and --%s can't be used together", seen[xor].Name, flag.Name)
+		}
+	}
+	allGroups := [][]*Path{rootGroup}
+	for _, g := range commandGroups {
+		allGroups = append(allGroups, g)
+	}
+	for _, groupPaths := range allGroups {
+		seen := map[string]*Value{}
+		for _, path := range groupPaths {
+			for _, flag := range path.Flags {
+				if !flag.Set {
+					continue
 				}
-				seen[xor] = flag
+				for _, xor := range flag.Xor {
+					if seen[xor] != nil {
+						return fmt.Errorf("%s and %s can't be used together", seen[xor].ShortSummary(), flag.ShortSummary())
+					}
+					seen[xor] = flag.Value
+				}
+			}
+			if path.Positional != nil && path.Positional.Set {
+				for _, xor := range path.Positional.Tag.Xor {
+					if seen[xor] != nil {
+						return fmt.Errorf("%s and %s can't be used together", seen[xor].ShortSummary(), path.Positional.ShortSummary())
+					}
+					seen[xor] = path.Positional
+				}
 			}
 		}
 	}
 	return nil
 }
 
-func checkAndMissing(paths []*Path) error {
+func checkAndMissing(paths []*Path, node *Node) error {
+	// Group paths by command scope (same logic as checkXorDuplicates).
+	rootGroup := []*Path{}
+	commandGroups := map[*Node][]*Path{}
+	hasRoot := false
 	for _, path := range paths {
-		missingMsgs := []string{}
-		andGroups := map[string][]*Flag{}
-		for _, flag := range path.Flags {
-			for _, and := range flag.And {
-				andGroups[and] = append(andGroups[and], flag)
+		if path.App != nil || (path.Parent == nil && (len(path.Flags) > 0 || path.Positional != nil)) {
+			rootGroup = append(rootGroup, path)
+			hasRoot = true
+		} else if path.Parent != nil && len(path.Flags) > 0 {
+			commandGroups[path.Parent] = append(commandGroups[path.Parent], path)
+		} else if path.Parent != nil && path.Positional != nil {
+			if hasRoot {
+				rootGroup = append(rootGroup, path)
+			} else {
+				commandGroups[path.Parent] = append(commandGroups[path.Parent], path)
 			}
 		}
-		for _, flags := range andGroups {
+	}
+	allGroups := [][]*Path{rootGroup}
+	for _, g := range commandGroups {
+		allGroups = append(allGroups, g)
+	}
+	missingMsgs := []string{}
+	for _, groupPaths := range allGroups {
+		andGroups := map[string][]*Value{}
+		for _, path := range groupPaths {
+			for _, flag := range path.Flags {
+				for _, and := range flag.And {
+					andGroups[and] = append(andGroups[and], flag.Value)
+				}
+			}
+			if path.Positional != nil {
+				for _, and := range path.Positional.Tag.And {
+					andGroups[and] = append(andGroups[and], path.Positional)
+				}
+			}
+		}
+		// Also include positional args from the model node that have and/xor tags
+		// but weren't in any path (e.g., optional positional not provided).
+		if node != nil {
+			for _, pos := range node.Positional {
+				if len(pos.Tag.And) > 0 {
+					alreadyIncluded := false
+					for _, path := range groupPaths {
+						if path.Positional == pos {
+							alreadyIncluded = true
+							break
+						}
+					}
+					if !alreadyIncluded {
+						for _, and := range pos.Tag.And {
+							andGroups[and] = append(andGroups[and], pos)
+						}
+					}
+				}
+			}
+		}
+		for _, values := range andGroups {
 			oneSet := false
-			notSet := []*Flag{}
-			flagNames := []string{}
-			for _, flag := range flags {
-				flagNames = append(flagNames, flag.Name)
-				if flag.Set {
+			notSet := []*Value{}
+			names := []string{}
+			for _, value := range values {
+				names = append(names, value.ShortSummary())
+				if value.Set {
 					oneSet = true
 				} else {
-					notSet = append(notSet, flag)
+					notSet = append(notSet, value)
 				}
 			}
 			if len(notSet) > 0 && oneSet {
-				missingMsgs = append(missingMsgs, fmt.Sprintf("--%s must be used together", strings.Join(flagNames, " and --")))
+				missingMsgs = append(missingMsgs, fmt.Sprintf("%s must be used together", strings.Join(names, " and ")))
 			}
 		}
-		if len(missingMsgs) > 0 {
-			return fmt.Errorf("%s", strings.Join(missingMsgs, ", "))
-		}
+	}
+	if len(missingMsgs) > 0 {
+		return fmt.Errorf("%s", strings.Join(missingMsgs, ", "))
 	}
 	return nil
 }

--- a/kong.go
+++ b/kong.go
@@ -189,6 +189,14 @@ func checkOverlappingXorAnd(k *Kong) error {
 			andGroups[and] = append(andGroups[and], flag.Name)
 		}
 	}
+	for _, positional := range k.Model.Node.Positional {
+		for _, xor := range positional.Tag.Xor {
+			xorGroups[xor] = append(xorGroups[xor], positional.Name)
+		}
+		for _, and := range positional.Tag.And {
+			andGroups[and] = append(andGroups[and], positional.Name)
+		}
+	}
 	for xor, xorSet := range xorGroups {
 		for and, andSet := range andGroups {
 			overlappingEntries := []string{}

--- a/kong_test.go
+++ b/kong_test.go
@@ -1294,6 +1294,65 @@ func TestAndRequiredMany(t *testing.T) {
 	assert.EqualError(t, err, "missing flags: --one and --two")
 }
 
+func TestXorWithPositional(t *testing.T) {
+	var cli struct {
+		Defaults bool     `xor:"group1" help:"Use defaults"`
+		Args     []string `arg:"" xor:"group1" optional:"" help:"Positional args"`
+	}
+
+	// Both provided — should error
+	p := mustNew(t, &cli)
+	_, err := p.Parse([]string{"--defaults", "foo", "bar"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "can't be used together")
+
+	// Only flag — should work
+	p = mustNew(t, &cli)
+	_, err = p.Parse([]string{"--defaults"})
+	assert.NoError(t, err)
+
+	// Only positional — should work
+	p = mustNew(t, &cli)
+	_, err = p.Parse([]string{"foo", "bar"})
+	assert.NoError(t, err)
+
+	// Neither — should work
+	p = mustNew(t, &cli)
+	_, err = p.Parse([]string{})
+	assert.NoError(t, err)
+}
+
+func TestXorFlagAndPositionalInverted(t *testing.T) {
+	var cli struct {
+		Args     []string `arg:"" xor:"group1" optional:"" help:"Positional args"`
+		Defaults bool     `xor:"group1" help:"Use defaults"`
+	}
+
+	// Both provided — should error regardless of field order
+	p := mustNew(t, &cli)
+	_, err := p.Parse([]string{"--defaults", "foo"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "can't be used together")
+}
+
+func TestAndWithPositional(t *testing.T) {
+	var cli struct {
+		Defaults bool     `and:"group1"`
+		Args     []string `arg:"" and:"group1" optional:"" help:"Positional args"`
+	}
+
+	// Only flag without positional — should error (and requires both)
+	p := mustNew(t, &cli)
+	_, err := p.Parse([]string{"--defaults"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must be used together")
+
+	// Both provided — should work
+	p = mustNew(t, &cli)
+	_, err = p.Parse([]string{"--defaults", "foo"})
+	assert.NoError(t, err)
+}
+
 func TestEnumSequence(t *testing.T) {
 	var cli struct {
 		State []string `enum:"a,b,c" default:"a"`


### PR DESCRIPTION
Fixes #255

## Problem
`xor` and `and` group validation only worked for flags, not positional arguments. Providing both a flag and a positional arg in the same xor group did not produce an error.

## Changes
- **context.go**: Extended `checkMissingFlags`, `checkXorDuplicates`, and `checkAndMissing` to include positional arguments in xor/and group validation
- **kong.go**: Extended `checkOverlappingXorAnd` to also scan positional arguments for xor/and group membership
- Error messages now use `ShortSummary()` instead of hardcoded `--%s` format, so they correctly display both flag names (`--flag`) and positional arg names

## Example
```go
type CLI struct {
    Defaults bool     `xor:"group1" help:"Use defaults"`
    Args     []string `arg:"" xor:"group1" optional:"" help:"Positional args"`
}
```
Before: `run --defaults foo bar` → no error
After: `run --defaults foo bar` → error: "--defaults and args can't be used together"

## Tests
All existing tests pass. The fix is backward-compatible since positional args without xor/and tags are unaffected.