### PR TITLE
treat single-character aliases as short flags

### DIFF
--- a/build.go
+++ b/build.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"unicode/utf8"
 )
 
 // Plugins are dynamically embedded command-line structures.
@@ -344,6 +345,9 @@ func buildField(k *Kong, node *Node, v reflect.Value, ft reflect.StructField, fv
 		seenFlags["--"+value.Name] = true
 		for _, alias := range tag.Aliases {
 			aliasFlag := "--" + alias
+			if utf8.RuneCountInString(alias) == 1 {
+				aliasFlag = "-" + alias
+			}
 			if seenFlags[aliasFlag] {
 				return failField(v, ft, "duplicate flag %s", aliasFlag)
 			}

--- a/context.go
+++ b/context.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 )
 
 // Path records the nodes and parsed values from the current command-line.
@@ -746,9 +747,12 @@ func (c *Context) parseFlag(flags []*Flag, match string) (err error) {
 			candidates = append(candidates, short)
 		}
 		for _, alias := range flag.Aliases {
-			alias = "--" + alias
-			matched = matched || (alias == match)
-			candidates = append(candidates, alias)
+			aliasFlag := "--" + alias
+			if utf8.RuneCountInString(alias) == 1 {
+				aliasFlag = "-" + alias
+			}
+			matched = matched || (aliasFlag == match)
+			candidates = append(candidates, aliasFlag)
 		}
 
 		neg := negatableFlagName(flag.Name, flag.Tag.Negatable)

--- a/kong_test.go
+++ b/kong_test.go
@@ -669,6 +669,16 @@ func TestAlias(t *testing.T) {
 	assert.Equal(t, "hello", cli.String)
 }
 
+func TestSingleCharAliasIsShortFlag(t *testing.T) {
+	var cli struct {
+		Number string `aliases:"n,num"`
+	}
+	app := mustNew(t, &cli)
+	_, err := app.Parse([]string{"-n", "hello"})
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", cli.Number)
+}
+
 func TestDuplicateFlagChoosesLast(t *testing.T) {
 	var cli struct {
 		Flag int


### PR DESCRIPTION
\`aliases:\"n,name\"\` set up both \`n\` and \`name\` as long flags, so \`-n\` didn't match. Single-rune aliases now resolve as short flags instead, since that's clearly the intent and there's no other way to declare a short alias today. Existing multi-char aliases (the \`TestAlias\` case \`--str\`) keep working unchanged.

Touches \`context.go\` (parse match) and \`build.go\` (the dedup check uses the same prefix). Test added: \`TestSingleCharAliasIsShortFlag\` with \`aliases:\"n,num\"\` parsed via \`-n hello\`.

fixes #589