### PR TITLE
Allow a node with a Run() method to run without a subcommand

### DIFF
--- a/context.go
+++ b/context.go
@@ -972,6 +972,10 @@ func checkMissingChildren(node *Node) error {
 		missing = append(missing, strconv.Quote(strings.Join(missingArgs, " ")))
 	}
 
+	// A node with a Run() method may run on its own, so it does not require one
+	// of its subcommands to be selected.
+	runnable := node.Target.IsValid() && getMethod(node.Target, "Run").IsValid()
+
 	for _, child := range node.Children {
 		if child.Hidden {
 			continue
@@ -981,7 +985,7 @@ func checkMissingChildren(node *Node) error {
 				continue
 			}
 			missing = append(missing, strconv.Quote(child.Summary()))
-		} else {
+		} else if !runnable {
 			missing = append(missing, strconv.Quote(child.Name))
 		}
 	}

--- a/kong_test.go
+++ b/kong_test.go
@@ -806,6 +806,45 @@ func TestRun(t *testing.T) {
 	assert.Equal(t, "argping", cli.Three.SubCommand.Arg)
 }
 
+type rootWithRun struct {
+	ran     bool
+	SubCmd1 struct{} `cmd:""`
+	SubCmd2 struct{} `cmd:""`
+}
+
+func (r *rootWithRun) Run() error {
+	r.ran = true
+	return nil
+}
+
+func TestRunnableNodeDoesNotRequireSubcommand(t *testing.T) {
+	t.Run("runs the node when no subcommand is given", func(t *testing.T) {
+		cli := &rootWithRun{}
+		p := mustNew(t, cli)
+		ctx, err := p.Parse([]string{})
+		assert.NoError(t, err)
+		assert.NoError(t, ctx.Run())
+		assert.True(t, cli.ran)
+	})
+
+	t.Run("still allows selecting a subcommand", func(t *testing.T) {
+		cli := &rootWithRun{}
+		p := mustNew(t, cli)
+		_, err := p.Parse([]string{"sub-cmd-1"})
+		assert.NoError(t, err)
+	})
+
+	t.Run("still requires a subcommand without a Run method", func(t *testing.T) {
+		var cli struct {
+			SubCmd1 struct{} `cmd:""`
+			SubCmd2 struct{} `cmd:""`
+		}
+		p := mustNew(t, &cli)
+		_, err := p.Parse([]string{})
+		assert.Error(t, err)
+	})
+}
+
 type failCmd struct{}
 
 func (f failCmd) Run() error {


### PR DESCRIPTION
Fixes #561

A node that declares subcommands but also defines a `Run()` method cannot currently be invoked on its own. Running the app with no subcommand fails with `expected one of ...`, even though `Run()` is defined.

This matches the approach suggested in the issue: if a node has a `Run()` method it can act as a terminating command. `checkMissingChildren` no longer requires one of the subcommands to be selected when the node is runnable. `ctx.Run()` already runs such a node (the application node with a `Run()` method), so no change was needed there.

Subcommands still work, and nodes without a `Run()` method still require a subcommand. Added tests for all three cases.
