### PR TITLE
feat: allow `cmd` and `arg` tags to set names

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ var CLI struct {
     Force     bool `help:"Force removal."`
     Recursive bool `help:"Recursively remove files."`
 
-    Paths []string `arg:"" name:"path" help:"Paths to remove." type:"path"`
+    Paths []string `arg:"path" help:"Paths to remove." type:"path"`
   } `cmd:"" help:"Remove files."`
 
   Ls struct {
-    Paths []string `arg:"" optional:"" name:"path" help:"Paths to list." type:"path"`
+    Paths []string `arg:"path" optional:"" help:"Paths to list." type:"path"`
   } `cmd:"" help:"List paths."`
 }
 
@@ -220,11 +220,11 @@ var CLI struct {
     Force     bool `help:"Force removal."`
     Recursive bool `help:"Recursively remove files."`
 
-    Paths []string `arg:"" name:"path" help:"Paths to remove." type:"path"`
+    Paths []string `arg:"path" help:"Paths to remove." type:"path"`
   } `cmd:"" help:"Remove files."`
 
   Ls struct {
-    Paths []string `arg:"" optional:"" name:"path" help:"Paths to list." type:"path"`
+    Paths []string `arg:"path" optional:"" help:"Paths to list." type:"path"`
   } `cmd:"" help:"List paths."`
 }
 
@@ -273,7 +273,7 @@ type RmCmd struct {
   Force     bool `help:"Force removal."`
   Recursive bool `help:"Recursively remove files."`
 
-  Paths []string `arg:"" name:"path" help:"Paths to remove." type:"path"`
+  Paths []string `arg:"path" help:"Paths to remove." type:"path"`
 }
 
 func (r *RmCmd) Run(ctx *Context) error {
@@ -282,7 +282,7 @@ func (r *RmCmd) Run(ctx *Context) error {
 }
 
 type LsCmd struct {
-  Paths []string `arg:"" optional:"" name:"path" help:"Paths to list." type:"path"`
+  Paths []string `arg:"path" optional:"" help:"Paths to list." type:"path"`
 }
 
 func (l *LsCmd) Run(ctx *Context) error {
@@ -399,7 +399,7 @@ type CLI struct {
 
 ## Commands and sub-commands
 
-Sub-commands are specified by tagging a struct field with `cmd`. Kong supports arbitrarily nested commands.
+Sub-commands are specified by tagging a struct field with `cmd`. Kong supports arbitrarily nested commands. If `cmd` has a non-empty value, that value will be used as the command name unless `name` is also specified.
 
 eg. The following struct represents the CLI structure `command [--flag="str"] sub-command`.
 
@@ -447,7 +447,9 @@ This looks a little verbose in this contrived example, but typically this will n
 
 If a field is tagged with `arg:""` it will be treated as the final positional
 value to be parsed on the command line. By default positional arguments are
-required, but specifying `optional:""` will alter this.
+required, but specifying `optional:""` will alter this. If `arg` has a
+non-empty value, that value will be used as the argument name unless `name` is
+also specified.
 
 If a positional argument is a slice, all remaining arguments will be appended
 to that slice.
@@ -569,7 +571,9 @@ Both can coexist with standard Tag parsing.
 | Tag                  | Description                                                                                                                                                                                                                                                                                                                    |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `cmd:""`             | If present, struct is a command.                                                                                                                                                                                                                                                                                               |
+| `cmd:"X"`            | If `name` is unset, `X` is used as the command name.                                                                                                                                                                                                                                                                           |
 | `arg:""`             | If present, field is an argument. Required by default.                                                                                                                                                                                                                                                                         |
+| `arg:"X"`            | If `name` is unset, `X` is used as the argument name.                                                                                                                                                                                                                                                                          |
 | `env:"X,Y,..."`      | Specify envars to use for default value. The envs are resolved in the declared order. The first value found is used.                                                                                                                                                                                                           |
 | `name:"X"`           | Long name, for overriding field name.                                                                                                                                                                                                                                                                                          |
 | `help:"X"`           | Help text.                                                                                                                                                                                                                                                                                                                     |

--- a/tag.go
+++ b/tag.go
@@ -274,6 +274,13 @@ func hydrateTag(t *Tag, typ reflect.Type) error { //nolint: gocyclo
 		t.Required = true
 	}
 	t.Name = t.Get("name")
+	if t.Name == "" {
+		if t.Cmd {
+			t.Name = t.Get("cmd")
+		} else if t.Arg {
+			t.Name = t.Get("arg")
+		}
+	}
 	t.Help = t.Get("help")
 	t.Type = t.Get("type")
 	t.TypeName = typeName

--- a/tag_test.go
+++ b/tag_test.go
@@ -244,3 +244,18 @@ func TestInvalidRuneErrors(t *testing.T) {
 	_, err := kong.New(&cli)
 	assert.EqualError(t, err, "<anonymous struct>.Flag: invalid short flag name \"invalid\": invalid rune")
 }
+
+func TestTagNameFromCmdAndArg(t *testing.T) {
+	type Command struct {
+		Arg string `arg:"bar"`
+	}
+	var cli struct {
+		Cmd Command `cmd:"foo"`
+	}
+	p := mustNew(t, &cli, kong.Exit(func(int) {}))
+	ctx, err := p.Parse([]string{"foo", "arg"})
+	assert.NoError(t, err)
+	assert.Equal(t, "arg", cli.Cmd.Arg)
+	assert.Equal(t, "foo", ctx.Model.Children[0].Name)
+	assert.Equal(t, "bar", ctx.Model.Children[0].Positional[0].Name)
+}


### PR DESCRIPTION
This PR lets non-empty `cmd` and `arg` tag values supply the command or argument name when `name` is omitted.

This keeps `name` as the explicit override while allowing `cmd:"foo"` and `arg:"bar"` as shorter forms of `cmd:"" name:"foo"` and `arg:"" name:"bar"`.
