### PR TITLE
fix: correct typos in resolver.go and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ A more robust approach is to break each command out into their own structs:
 
 Once a command node is selected by Kong it will search from that node back to the root. Each
 encountered command node with a `Run(...) error` will be called in reverse order. This allows
-sub-trees to be re-used fairly conveniently.
+sub-trees to be reused fairly conveniently.
 
 In addition to values bound with the `kong.Bind(...)` option, any values
 passed through to `kong.Context.Run(...)` are also bindable to the target's

--- a/resolver.go
+++ b/resolver.go
@@ -29,7 +29,7 @@ func (r ResolverFunc) Validate(app *Application) error { return nil } //nolint: 
 
 // JSON returns a Resolver that retrieves values from a JSON source.
 //
-// Flag names are used as JSON keys indirectly, by tring snake_case and camelCase variants.
+// Flag names are used as JSON keys indirectly, by trying snake_case and camelCase variants.
 func JSON(r io.Reader) (Resolver, error) {
 	values := map[string]any{}
 	err := json.NewDecoder(r).Decode(&values)


### PR DESCRIPTION
Fix two typos found via codespell:

- `resolver.go:32`: `tring` → `trying` in the `JSON` resolver doc comment
- `README.md:255`: `re-used` → `reused` for consistency with surrounding text

🤖 Generated with [Claude Code](https://claude.com/claude-code)