### PR TITLE
feat: Support negatable bool mappers

### DIFF
--- a/build.go
+++ b/build.go
@@ -360,6 +360,9 @@ func buildField(k *Kong, node *Node, v reflect.Value, ft reflect.StructField, fv
 			seenFlags["-"+string(tag.Short)] = true
 		}
 		if tag.Negatable != "" {
+			if !value.IsBool() {
+				return failField(v, ft, "negatable can only be set on booleans")
+			}
 			negFlag := negatableFlagName(value.Name, tag.Negatable)
 			if seenFlags[negFlag] {
 				return failField(v, ft, "duplicate negation flag %s", negFlag)

--- a/context.go
+++ b/context.go
@@ -718,22 +718,6 @@ func (c *Context) Apply() (string, error) {
 	return strings.Join(path, " "), nil
 }
 
-func flipBoolValue(value reflect.Value) error {
-	if value.Kind() == reflect.Bool {
-		value.SetBool(!value.Bool())
-		return nil
-	}
-
-	if value.Kind() == reflect.Ptr {
-		if !value.IsNil() {
-			return flipBoolValue(value.Elem())
-		}
-		return nil
-	}
-
-	return fmt.Errorf("cannot negate a value of %s", value.Type().String())
-}
-
 func (c *Context) parseFlag(flags []*Flag, match string) (err error) {
 	candidates := []string{}
 
@@ -761,8 +745,22 @@ func (c *Context) parseFlag(flags []*Flag, match string) (err error) {
 		}
 		// Found a matching flag.
 		c.scan.Pop()
-		if match == neg && flag.Tag.Negatable != "" {
-			flag.Negated = true
+		flag.Negated = match == neg && flag.Tag.Negatable != ""
+		if flag.Negated {
+			negatedValue := true
+			if c.scan.Peek().Type == FlagValueToken {
+				token, err := c.scan.PopValue("bool")
+				if err != nil {
+					return err
+				}
+				negatedValue, err = parseBoolToken(token)
+				if err != nil {
+					return err
+				}
+			}
+			// Invert the boolean token before Decode so custom bool mappers
+			// keep ownership of their field representation.
+			c.scan.PushTyped(!negatedValue, FlagValueToken)
 		}
 		err := flag.Parse(c.scan, c.getValue(flag.Value))
 		if err != nil {
@@ -771,14 +769,6 @@ func (c *Context) parseFlag(flags []*Flag, match string) (err error) {
 				return fmt.Errorf("%s; perhaps try %s=%q?", err.Error(), flag.ShortSummary(), expected.token)
 			}
 			return err
-		}
-		if flag.Negated {
-			value := c.getValue(flag.Value)
-			err := flipBoolValue(value)
-			if err != nil {
-				return err
-			}
-			flag.Value.Apply(value)
 		}
 		c.Path = append(c.Path, &Path{
 			Flag:      flag,

--- a/kong_test.go
+++ b/kong_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -469,6 +471,121 @@ func TestNegatableFlag(t *testing.T) {
 		})
 	}
 }
+
+func TestNegatableFlagWithBoolMapper(t *testing.T) {
+	var cli struct {
+		Cmd struct {
+			Flag string `kong:"type='bool-string',negatable,default='true'"`
+		} `kong:"cmd"`
+	}
+	parser, err := kong.New(&cli, kong.NamedMapper("bool-string", boolStringMapper{}))
+	assert.NoError(t, err)
+
+	_, err = parser.Parse([]string{"cmd", "--no-flag"})
+	assert.NoError(t, err)
+	assert.Equal(t, "false", cli.Cmd.Flag)
+}
+
+type boolStringMapper struct{}
+
+func (boolStringMapper) Decode(ctx *kong.DecodeContext, target reflect.Value) error {
+	if ctx.Scan.Peek().Type != kong.FlagValueToken {
+		target.SetString("true")
+		return nil
+	}
+	token, err := ctx.Scan.PopValue("bool")
+	if err != nil {
+		return err
+	}
+	switch value := token.Value.(type) {
+	case bool:
+		target.SetString(fmt.Sprintf("%t", value))
+	case string:
+		parsed, err := strconv.ParseBool(value)
+		if err != nil {
+			return err
+		}
+		target.SetString(fmt.Sprintf("%t", parsed))
+	default:
+		return fmt.Errorf("expected bool but got %q (%T)", token.Value, token.Value)
+	}
+	return nil
+}
+
+func (boolStringMapper) IsBool() bool { return true }
+
+func TestNegatableFlagWithBoolMapperValue(t *testing.T) {
+	type Cmd struct {
+		Flag boolEnum `negatable:""`
+	}
+
+	tests := []struct {
+		name  string
+		input []string
+		want  boolEnum
+	}{
+		{"Default", nil, boolEnumAuto},
+		{"True", []string{"--flag"}, boolEnumAlways},
+		{"False", []string{"--no-flag"}, boolEnumNever},
+		{"Never", []string{"--flag=never"}, boolEnumNever},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cli Cmd
+			parser, err := kong.New(&cli)
+			assert.NoError(t, err)
+
+			_, err = parser.Parse(tt.input)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.want, cli.Flag)
+		})
+	}
+}
+
+type boolEnum int
+
+const (
+	boolEnumAuto boolEnum = iota
+	boolEnumAlways
+	boolEnumNever
+)
+
+func (b *boolEnum) Decode(ctx *kong.DecodeContext) error {
+	if ctx.Scan.Peek().Type != kong.FlagValueToken {
+		*b = boolEnumAlways // --flag without value
+		return nil
+	}
+	token, err := ctx.Scan.PopValue("bool")
+	if err != nil {
+		return err
+	}
+	switch value := token.Value.(type) {
+	case bool:
+		if value {
+			*b = boolEnumAlways
+		} else {
+			*b = boolEnumNever
+		}
+	case string:
+		switch strings.ToLower(value) {
+		case "auto":
+			*b = boolEnumAuto
+		case "always":
+			*b = boolEnumAlways
+		case "never":
+			*b = boolEnumNever
+		default:
+			return fmt.Errorf("invalid value: %q", value)
+		}
+	default:
+		return fmt.Errorf("expected bool but got %q (%T)", token.Value, token.Value)
+	}
+	return nil
+}
+
+func (*boolEnum) IsBool() bool { return true }
 
 func TestDuplicateNegatableLong(t *testing.T) {
 	cli2 := struct {

--- a/mapper.go
+++ b/mapper.go
@@ -298,32 +298,36 @@ type boolMapper struct{}
 func (boolMapper) Decode(ctx *DecodeContext, target reflect.Value) error {
 	if ctx.Scan.Peek().Type == FlagValueToken {
 		token := ctx.Scan.Pop()
-		switch v := token.Value.(type) {
-		case string:
-			v = strings.ToLower(v)
-			switch v {
-			case "true", "1", "yes":
-				target.SetBool(true)
-
-			case "false", "0", "no":
-				target.SetBool(false)
-
-			default:
-				return fmt.Errorf("bool value must be true, 1, yes, false, 0 or no but got %q", v)
-			}
-
-		case bool:
-			target.SetBool(v)
-
-		default:
-			return fmt.Errorf("expected bool but got %q (%T)", token.Value, token.Value)
+		value, err := parseBoolToken(token)
+		if err != nil {
+			return err
 		}
+		target.SetBool(value)
 	} else {
 		target.SetBool(true)
 	}
 	return nil
 }
 func (boolMapper) IsBool() bool { return true }
+
+func parseBoolToken(token Token) (bool, error) {
+	switch value := token.Value.(type) {
+	case string:
+		value = strings.ToLower(value)
+		switch value {
+		case "true", "1", "yes":
+			return true, nil
+		case "false", "0", "no":
+			return false, nil
+		default:
+			return false, fmt.Errorf("bool value must be true, 1, yes, false, 0 or no but got %q", value)
+		}
+	case bool:
+		return value, nil
+	default:
+		return false, fmt.Errorf("expected bool but got %q (%T)", token.Value, token.Value)
+	}
+}
 
 func durationDecoder() MapperFunc {
 	return func(ctx *DecodeContext, target reflect.Value) error {

--- a/tag.go
+++ b/tag.go
@@ -248,12 +248,8 @@ func parseTag(parent reflect.Value, ft reflect.StructField) (*Tag, error) {
 
 func hydrateTag(t *Tag, typ reflect.Type) error { //nolint: gocyclo
 	var typeName string
-	var isBool bool
-	var isBoolPtr bool
 	if typ != nil {
 		typeName = typ.Name()
-		isBool = typ.Kind() == reflect.Bool
-		isBoolPtr = typ.Kind() == reflect.Ptr && typ.Elem().Kind() == reflect.Bool
 	}
 	var err error
 	t.Cmd = t.Has("cmd")
@@ -300,9 +296,6 @@ func hydrateTag(t *Tag, typ reflect.Type) error { //nolint: gocyclo
 	t.XorPrefix = t.Get("xorprefix")
 	t.Embed = t.Has("embed")
 	if t.Has("negatable") {
-		if !isBool && !isBoolPtr {
-			return fmt.Errorf("negatable can only be set on booleans")
-		}
 		negatable := t.Get("negatable")
 		if negatable == "" {
 			negatable = negatableDefault // placeholder for default negation of --no-<flag>


### PR DESCRIPTION
`negatable:""` now supports usage with custom boolean values (IsBool),
for both Decoder and MapperValue implementations.
