### PR TITLE
Fix env var validation conflicts

### DIFF
--- a/context.go
+++ b/context.go
@@ -195,7 +195,7 @@ func (c *Context) Validate() error { //nolint: gocyclo
 		if node == nil {
 			continue
 		}
-		for _, value := range nodeValues(node) {
+		for _, value := range node.Values() {
 			ok := atLeastOneEnvSet(value.Tag.Envs)
 			if value.Enum != "" && (!value.Required || value.HasDefault || (len(value.Tag.Envs) != 0 && ok)) {
 				if err := checkEnum(value, value.Target); err != nil {
@@ -343,52 +343,35 @@ func (c *Context) FlagValue(flag *Flag) any {
 
 // Reset recursively resets values to defaults (as specified in the grammar) or the zero value.
 func (c *Context) Reset() error {
-	selected := c.selectedNodes()
-	var reset func(node *Node) error
-	reset = func(node *Node) error {
-		for _, value := range nodeValues(node) {
-			if err := value.Reset(); err != nil {
-				if selected[node] {
-					return err
-				}
-				// An envar shared with a node outside the selected command
-				// path may not parse there; that must not fail this parse.
-				value.Target.Set(reflect.Zero(value.Target.Type()))
-			}
+	selected := c.selectedValues()
+	return Visit(c.Model.Node, func(node Visitable, next Next) error {
+		value, ok := node.(*Value)
+		if !ok {
+			return next(nil)
 		}
-		for _, child := range node.Children {
-			if err := reset(child); err != nil {
-				return err
-			}
+		err := value.Reset()
+		if err != nil && !selected[value] {
+			// An envar shared with a node outside the selected command path
+			// may not parse there; that must not fail this parse.
+			value.Target.Set(reflect.Zero(value.Target.Type()))
+			err = nil
 		}
-		return nil
-	}
-	return reset(c.Model.Node)
+		return next(err)
+	})
 }
 
-// selectedNodes returns the set of nodes on the traced command path.
-func (c *Context) selectedNodes() map[*Node]bool {
-	selected := map[*Node]bool{}
+// selectedValues returns the set of values attached to nodes on the traced
+// command path.
+func (c *Context) selectedValues() map[*Value]bool {
+	selected := map[*Value]bool{}
 	for _, path := range c.Path {
 		if node := path.Node(); node != nil {
-			selected[node] = true
+			for _, value := range node.Values() {
+				selected[value] = true
+			}
 		}
 	}
 	return selected
-}
-
-// nodeValues returns the values directly attached to a node: its argument
-// value, flag values and positionals.
-func nodeValues(node *Node) []*Value {
-	values := []*Value{}
-	if node.Argument != nil {
-		values = append(values, node.Argument)
-	}
-	for _, flag := range node.Flags {
-		values = append(values, flag.Value)
-	}
-	values = append(values, node.Positional...)
-	return values
 }
 
 func (c *Context) endParsing() {

--- a/context.go
+++ b/context.go
@@ -188,28 +188,21 @@ func (c *Context) Empty() bool {
 
 // Validate the current context.
 func (c *Context) Validate() error { //nolint: gocyclo
-	err := Visit(c.Model, func(node Visitable, next Next) error {
-		switch node := node.(type) {
-		case *Value:
-			ok := atLeastOneEnvSet(node.Tag.Envs)
-			if node.Enum != "" && (!node.Required || node.HasDefault || (len(node.Tag.Envs) != 0 && ok)) {
-				if err := checkEnum(node, node.Target); err != nil {
-					return err
-				}
-			}
-
-		case *Flag:
-			ok := atLeastOneEnvSet(node.Tag.Envs)
-			if node.Enum != "" && (!node.Required || node.HasDefault || (len(node.Tag.Envs) != 0 && ok)) {
-				if err := checkEnum(node.Value, node.Target); err != nil {
+	// Only check nodes on the selected command path: an envar shared with
+	// another command may hold a value that is invalid there.
+	for _, path := range c.Path {
+		node := path.Node()
+		if node == nil {
+			continue
+		}
+		for _, value := range nodeValues(node) {
+			ok := atLeastOneEnvSet(value.Tag.Envs)
+			if value.Enum != "" && (!value.Required || value.HasDefault || (len(value.Tag.Envs) != 0 && ok)) {
+				if err := checkEnum(value, value.Target); err != nil {
 					return err
 				}
 			}
 		}
-		return next(nil)
-	})
-	if err != nil {
-		return err
 	}
 	for _, el := range c.Path {
 		var (
@@ -350,12 +343,52 @@ func (c *Context) FlagValue(flag *Flag) any {
 
 // Reset recursively resets values to defaults (as specified in the grammar) or the zero value.
 func (c *Context) Reset() error {
-	return Visit(c.Model.Node, func(node Visitable, next Next) error {
-		if value, ok := node.(*Value); ok {
-			return next(value.Reset())
+	selected := c.selectedNodes()
+	var reset func(node *Node) error
+	reset = func(node *Node) error {
+		for _, value := range nodeValues(node) {
+			if err := value.Reset(); err != nil {
+				if selected[node] {
+					return err
+				}
+				// An envar shared with a node outside the selected command
+				// path may not parse there; that must not fail this parse.
+				value.Target.Set(reflect.Zero(value.Target.Type()))
+			}
 		}
-		return next(nil)
-	})
+		for _, child := range node.Children {
+			if err := reset(child); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return reset(c.Model.Node)
+}
+
+// selectedNodes returns the set of nodes on the traced command path.
+func (c *Context) selectedNodes() map[*Node]bool {
+	selected := map[*Node]bool{}
+	for _, path := range c.Path {
+		if node := path.Node(); node != nil {
+			selected[node] = true
+		}
+	}
+	return selected
+}
+
+// nodeValues returns the values directly attached to a node: its argument
+// value, flag values and positionals.
+func nodeValues(node *Node) []*Value {
+	values := []*Value{}
+	if node.Argument != nil {
+		values = append(values, node.Argument)
+	}
+	for _, flag := range node.Flags {
+		values = append(values, flag.Value)
+	}
+	values = append(values, node.Positional...)
+	return values
 }
 
 func (c *Context) endParsing() {

--- a/model.go
+++ b/model.go
@@ -130,6 +130,20 @@ func (n *Node) Leaves(hide bool) (out []*Node) {
 	return
 }
 
+// Values returns the values directly attached to this node: its argument
+// value, flag values and positionals.
+func (n *Node) Values() []*Value {
+	values := []*Value{}
+	if n.Argument != nil {
+		values = append(values, n.Argument)
+	}
+	for _, flag := range n.Flags {
+		values = append(values, flag.Value)
+	}
+	values = append(values, n.Positional...)
+	return values
+}
+
 // Depth of the command from the application root.
 func (n *Node) Depth() int {
 	depth := 0

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -2,6 +2,7 @@ package kong_test
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -148,6 +149,83 @@ func TestEnvarsWithDefault(t *testing.T) {
 	_, err = parser.Parse(nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "moo", cli.Flag)
+}
+
+type enableDisable struct {
+	enabled bool
+}
+
+func (ed *enableDisable) Decode(ctx *kong.DecodeContext) error {
+	var v string
+	err := ctx.Scan.PopValueInto("enable-disable", &v)
+	if err != nil {
+		return err
+	}
+	switch strings.ToLower(v) {
+	case "enable", "true":
+		ed.enabled = true
+	case "disable", "false":
+		ed.enabled = false
+	default:
+		return fmt.Errorf("enable-disable value should be 'enable' or 'disable' but was %q", v)
+	}
+	return nil
+}
+
+func TestEnvarsSharedBetweenCommands(t *testing.T) {
+	// An envar must only be applied and validated on the selected command,
+	// even when another command binds the same envar with incompatible
+	// constraints.
+	t.Run("enum and custom decoder", func(t *testing.T) {
+		var cli struct {
+			Cmd1 struct {
+				Action string `required:"" env:"KONG_ACTION" enum:"freeze,defrost,remove"`
+			} `cmd:""`
+			Cmd2 struct {
+				Action enableDisable `required:"" env:"KONG_ACTION"`
+			} `cmd:""`
+		}
+		parser := mustNew(t, &cli)
+
+		_, err := parser.Parse([]string{"cmd-1", "--action", "remove"})
+		assert.NoError(t, err)
+		assert.Equal(t, "remove", cli.Cmd1.Action)
+
+		t.Setenv("KONG_ACTION", "remove")
+		_, err = parser.Parse([]string{"cmd-1"})
+		assert.NoError(t, err)
+		assert.Equal(t, "remove", cli.Cmd1.Action)
+
+		t.Setenv("KONG_ACTION", "enable")
+		_, err = parser.Parse([]string{"cmd-2"})
+		assert.NoError(t, err)
+		assert.True(t, cli.Cmd2.Action.enabled)
+	})
+	t.Run("conflicting enums", func(t *testing.T) {
+		var cli struct {
+			Cmd1 struct {
+				Action string `required:"" env:"KONG_ACTION" enum:"freeze,defrost,remove"`
+			} `cmd:""`
+			Cmd2 struct {
+				Action string `required:"" env:"KONG_ACTION" enum:"enable,disable"`
+			} `cmd:""`
+		}
+		parser := mustNew(t, &cli)
+
+		_, err := parser.Parse([]string{"cmd-1", "--action", "remove"})
+		assert.NoError(t, err)
+		assert.Equal(t, "remove", cli.Cmd1.Action)
+
+		t.Setenv("KONG_ACTION", "remove")
+		_, err = parser.Parse([]string{"cmd-1"})
+		assert.NoError(t, err)
+		assert.Equal(t, "remove", cli.Cmd1.Action)
+
+		t.Setenv("KONG_ACTION", "enable")
+		_, err = parser.Parse([]string{"cmd-2"})
+		assert.NoError(t, err)
+		assert.Equal(t, "enable", cli.Cmd2.Action)
+	})
 }
 
 func TestEnv(t *testing.T) {


### PR DESCRIPTION
Environment variables with matching names on two commands with the same parent were validated against the requirements of both commands.

Caused by `Reset()` and `Validate()` walking the entire tree rather than only the nodes on the selected path.

Note that, this changes some error behaviour slightly. For example, if a default value was not a member of an enum set the validation would always catch this even if the node was not in the selected path. 