### PR TITLE
fix: Call hooks from unexported embedded fields

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -163,6 +163,22 @@ func getMethods(value reflect.Value, name string) (methods []reflect.Value) {
 			methods = append(methods, method)
 		}
 	})
+	if len(methods) == 0 {
+		// No explicit method was found on the value
+		// or its exported embedded fields.
+		// An unexported anonymous field may still provide a promoted method:
+		//
+		//     type options struct{}
+		//     func (*options) AfterApply() error { return nil }
+		//     type CLI struct{ options }
+		//
+		// Reflection cannot safely visit the options field,
+		// but Go exposes CLI.AfterApply through a compiler-generated wrapper.
+		// Calling that wrapper here cannot duplicate a method found above.
+		if method := getMethod(value, name); method.IsValid() {
+			methods = append(methods, method)
+		}
+	}
 	return
 }
 

--- a/kong_test.go
+++ b/kong_test.go
@@ -2777,6 +2777,31 @@ func TestPromotedEmbeddedAfterApplyCalledOnce(t *testing.T) {
 	assert.Equal(t, 1, calls)
 }
 
+type unexportedEmbeddedAfterApply struct {
+	calls *int
+}
+
+func (e *unexportedEmbeddedAfterApply) AfterApply() error {
+	(*e.calls)++
+	return nil
+}
+
+type rootWithUnexportedEmbeddedAfterApply struct {
+	unexportedEmbeddedAfterApply
+}
+
+func TestPromotedUnexportedEmbeddedAfterApplyCalledOnce(t *testing.T) {
+	calls := 0
+	cli := &rootWithUnexportedEmbeddedAfterApply{
+		unexportedEmbeddedAfterApply: unexportedEmbeddedAfterApply{
+			calls: &calls,
+		},
+	}
+	_, err := mustNew(t, cli).Parse(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, calls)
+}
+
 type envOnlyAfterApply struct {
 	called bool
 }


### PR DESCRIPTION
Bug:
In #616, Kong stopped calling compiler-generated promoted methods.
It traversed exported embedded fields instead so each hook runs at its
declaring receiver.

That traversal cannot enter an unexported anonymous field. The promoted
method was ignored and the declaring receiver was skipped, so the hook
did not run. For example:

    type options struct{}

    func (*options) AfterApply() error { return nil }

    type CLI struct {
        options
    }

`CLI.AfterApply` is callable through Go's promoted method wrapper,
but the callback search introduced by #616 rejected that wrapper
and could not visit `options` through reflection.

Fix:
Fall back to the promoted method when traversal finds no explicit hook.
Exported embedded hooks still run at their declaring receiver once.
An unexported embedded hook runs through the callable parent wrapper.

Validation:
Includes a regression test that fails without this fix.