### PR TITLE
Fix panic when a float flag is resolved from an integer value

### DIFF
--- a/mapper.go
+++ b/mapper.go
@@ -446,10 +446,10 @@ func floatDecoder(bits int) MapperFunc {
 			target.SetFloat(v)
 
 		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-			target.Set(reflect.ValueOf(v))
+			target.SetFloat(reflect.ValueOf(v).Convert(reflect.TypeOf(float64(0))).Float())
 
 		default:
-			return fmt.Errorf("expected an int but got %q (%T)", t, t.Value)
+			return fmt.Errorf("expected a float but got %q (%T)", t, t.Value)
 		}
 		return nil
 	}

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -367,6 +367,25 @@ func TestResolverWithBool(t *testing.T) {
 	assert.True(t, cli.Bool)
 }
 
+func TestResolverWithFloatFromInt(t *testing.T) {
+	var cli struct {
+		Rate float64
+	}
+
+	var resolver kong.ResolverFunc = func(context *kong.Context, parent *kong.Path, flag *kong.Flag) (any, error) {
+		if flag.Name == "rate" {
+			return 5, nil
+		}
+		return nil, nil
+	}
+
+	p := mustNew(t, &cli, kong.Resolvers(resolver))
+
+	_, err := p.Parse(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 5.0, cli.Rate)
+}
+
 func TestLastResolverWins(t *testing.T) {
 	var cli struct {
 		Int []int


### PR DESCRIPTION
When a resolver returns an integer for a `float32`/`float64` flag, `floatDecoder` handled the integer case with `target.Set(reflect.ValueOf(v))`. Since an `int` is not assignable to a float field, this panics and crashes the whole program:

```
panic: reflect.Set: value of type int is not assignable to type float64
```

This is easy to hit because resolvers return `any` and typed config sources commonly yield integers for numeric fields.

### Reproduction

```go
var cli struct {
	Rate float64
}
resolver := kong.ResolverFunc(func(_ *kong.Context, _ *kong.Path, flag *kong.Flag) (any, error) {
	if flag.Name == "rate" {
		return 5, nil // int, not float
	}
	return nil, nil
})
kong.Must(&cli, kong.Resolvers(resolver)).Parse(nil) // panics
```

### Fix

Convert the integer to a float and use `SetFloat`, matching the other branches in `floatDecoder` and the existing pattern in `durationDecoder`. The `default` branch error message was also a copy from `intDecoder` ("expected an int") and is corrected to "expected a float".

Added a regression test (`TestResolverWithFloatFromInt`) that panics before the change and passes after. Full suite passes.