### PR TITLE
Fix panic on a set tag without a value

### DIFF
--- a/tag.go
+++ b/tag.go
@@ -316,7 +316,7 @@ func hydrateTag(t *Tag, typ reflect.Type) error { //nolint: gocyclo
 	t.Vars = Vars{}
 	for _, set := range t.GetAll("set") {
 		parts := strings.SplitN(set, "=", 2)
-		if len(parts) == 0 {
+		if len(parts) != 2 {
 			return fmt.Errorf("set should be in the form key=value but got %q", set)
 		}
 		t.Vars[parts[0]] = parts[1]

--- a/tag_test.go
+++ b/tag_test.go
@@ -191,6 +191,14 @@ func TestTagSetOnFlag(t *testing.T) {
 	assert.Contains(t, buf.String(), `A key from somewhere.`)
 }
 
+func TestTagSetWithoutValueErrors(t *testing.T) {
+	cli := struct {
+		Flag string `set:"novalue"`
+	}{}
+	_, err := kong.New(&cli)
+	assert.EqualError(t, err, `<anonymous struct>.Flag: set should be in the form key=value but got "novalue"`)
+}
+
 func TestTagAliases(t *testing.T) {
 	type Command struct {
 		Arg string `arg help:"Some arg"`


### PR DESCRIPTION
A `set` tag without a `=` crashes the program instead of returning the error kong already wrote for it.

The guard contradicts its own next line:

```go
parts := strings.SplitN(set, "=", 2)
if len(parts) == 0 {
    return fmt.Errorf("set should be in the form key=value but got %q", set)
}
t.Vars[parts[0]] = parts[1]
```

`strings.SplitN` never returns a zero-length slice, so `len(parts) == 0` is dead code and `parts[1]` indexes a length-1 slice whenever the tag has no `=`.

### Reproduction

```go
var cli struct {
    Flag string `set:"novalue"`
}
_, err := kong.New(&cli)
```

```
panic: runtime error: index out of range [1] with length 1
```

For comparison, another malformed tag on a sibling path returns cleanly, and the well-formed case is unaffected:

```
Flag string `set:"novalue"`   ->  panic: index out of range [1] with length 1
Flag string `short:"ab"`      ->  error: <anonymous struct>.Flag: invalid short flag name "ab": invalid rune
Flag string `set:"k=v"`       ->  nil
```

The README documents the tag as `set:"K=V"`, so a missing `=` is an ordinary typo, and it reaches this through `kong.New` / `kong.Must` / `kong.Parse`.

### Fix

Compare against `len(parts) != 2`, so the message on the line above can actually fire:

```
<anonymous struct>.Flag: set should be in the form key=value but got "novalue"
```

Added `TestTagSetWithoutValueErrors` alongside `TestInvalidRuneErrors`, which is the same shape. `go test ./...` passes; `go vet` reports the same 78 pre-existing struct-tag warnings as on master.

---

Disclosure: this was found, written and verified by an AI coding agent (Claude Code) running on this account — the commit carries a `Co-Authored-By` trailer for it. The outputs above came from running the code, not reading it, but the agent ran them, not a person. Happy to adjust anything.
