### PR TITLE
fix: required flags aren't enforced when a default resolves to empty

### DIFF
--- a/kong.go
+++ b/kong.go
@@ -262,6 +262,18 @@ func (k *Kong) interpolateValue(value *Value, vars Vars) (err error) {
 	if value.Enum, err = interpolate(value.Enum, vars, nil); err != nil {
 		return fmt.Errorf("enum value for %s: %s", value.Summary(), err)
 	}
+
+	// HasDefault was set from the raw, uninterpolated tag string in hydrateTag, before
+	// any ${var} substitution ran - a default like "${var}" looks non-empty at that
+	// point even when var is unset. Recompute it now that Default is resolved, so a
+	// required field whose default resolves to "" is correctly treated as still unset
+	// (see checkMissingFlags) - unless "" is itself a declared enum member (e.g.
+	// enum:"one,two,"), in which case it's a legitimate, deliberately-chosen value
+	// rather than a missing one.
+	if value.Default == "" && !(value.Enum != "" && value.EnumMap()[""]) {
+		value.HasDefault = false
+	}
+
 	updatedVars := map[string]string{
 		"default": value.Default,
 		"enum":    value.Enum,

--- a/kong_test.go
+++ b/kong_test.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/alecthomas/assert/v2"
 	"github.com/alecthomas/repr"
@@ -215,6 +216,120 @@ func TestRequiredFlag(t *testing.T) {
 	parser := mustNew(t, &cli)
 	_, err := parser.Parse([]string{})
 	assert.Error(t, err)
+}
+
+// HasDefault is fixed at hydrateTag time from the raw, uninterpolated tag
+// string, so "${var_flag}" looks non-empty even when var_flag is unset -
+// interpolateValue must recompute it once the default is actually resolved,
+// or a required field silently ends up with an empty value instead of
+// erroring. Reset()'s "if v.HasDefault { Parse(...) }" is type-agnostic, so
+// this is exercised once per builtin Kind: the fix must short-circuit before
+// any type-specific mapper decode runs (a required bool field, for example,
+// would otherwise try to decode "" through boolMapper and fail with a
+// confusing "bool value must be true, 1, ..." error instead of a plain
+// "required" one).
+func TestRequiredFlagWithDefault(t *testing.T) {
+	// assert.Contains(err.Error(), "missing flags") rather than a bare
+	// assert.Error: some builtin mappers (bool, int, float, duration) fail
+	// to decode "" on their own regardless of the fix, which would make a
+	// bare assert.Error pass for the wrong reason (a decode error, not the
+	// required check) and mask a regression in the fix itself.
+	t.Run("string", func(t *testing.T) {
+		var cli struct {
+			Flag string `required:"" default:"${var_flag}"`
+		}
+		parser := mustNew(t, &cli, kong.Vars{"var_flag": ""})
+		_, err := parser.Parse(nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "missing flags")
+	})
+
+	t.Run("bool", func(t *testing.T) {
+		var cli struct {
+			Flag bool `required:"" default:"${var_flag}"`
+		}
+		parser := mustNew(t, &cli, kong.Vars{"var_flag": ""})
+		_, err := parser.Parse(nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "missing flags")
+	})
+
+	t.Run("int", func(t *testing.T) {
+		var cli struct {
+			Flag int `required:"" default:"${var_flag}"`
+		}
+		parser := mustNew(t, &cli, kong.Vars{"var_flag": ""})
+		_, err := parser.Parse(nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "missing flags")
+	})
+
+	t.Run("float64", func(t *testing.T) {
+		var cli struct {
+			Flag float64 `required:"" default:"${var_flag}"`
+		}
+		parser := mustNew(t, &cli, kong.Vars{"var_flag": ""})
+		_, err := parser.Parse(nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "missing flags")
+	})
+
+	t.Run("slice", func(t *testing.T) {
+		var cli struct {
+			Flag []string `required:"" default:"${var_flag}"`
+		}
+		parser := mustNew(t, &cli, kong.Vars{"var_flag": ""})
+		_, err := parser.Parse(nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "missing flags")
+	})
+
+	t.Run("map", func(t *testing.T) {
+		var cli struct {
+			Flag map[string]string `required:"" default:"${var_flag}"`
+		}
+		parser := mustNew(t, &cli, kong.Vars{"var_flag": ""})
+		_, err := parser.Parse(nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "missing flags")
+	})
+
+	t.Run("duration", func(t *testing.T) {
+		var cli struct {
+			Flag time.Duration `required:"" default:"${var_flag}"`
+		}
+		parser := mustNew(t, &cli, kong.Vars{"var_flag": ""})
+		_, err := parser.Parse(nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "missing flags")
+	})
+
+	// When the enum explicitly declares "" a valid member (trailing comma),
+	// a default resolving to "" is a legitimate, deliberately-chosen value -
+	// not a missing one - so the required check must not fire.
+	t.Run("enum permitting empty is not required", func(t *testing.T) {
+		var cli struct {
+			Flag string `required:"" enum:"one,two," default:"${var_flag}"`
+		}
+		parser, err := kong.New(&cli, kong.Name("test"), kong.Vars{"var_flag": ""})
+		assert.NoError(t, err)
+		_, err = parser.Parse(nil)
+		assert.NoError(t, err)
+	})
+
+	// Without a trailing comma, "" isn't a declared enum member, so a
+	// default resolving to "" is still treated as missing and the required
+	// check fires.
+	t.Run("enum not permitting empty is still required", func(t *testing.T) {
+		var cli struct {
+			Flag string `required:"" enum:"one,two" default:"${var_flag}"`
+		}
+		parser, err := kong.New(&cli, kong.Name("test"), kong.Vars{"var_flag": ""})
+		assert.NoError(t, err)
+		_, err = parser.Parse(nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "missing flags")
+	})
 }
 
 func TestOptionalArg(t *testing.T) {

--- a/kong_test.go
+++ b/kong_test.go
@@ -218,22 +218,7 @@ func TestRequiredFlag(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// HasDefault is fixed at hydrateTag time from the raw, uninterpolated tag
-// string, so "${var_flag}" looks non-empty even when var_flag is unset -
-// interpolateValue must recompute it once the default is actually resolved,
-// or a required field silently ends up with an empty value instead of
-// erroring. Reset()'s "if v.HasDefault { Parse(...) }" is type-agnostic, so
-// this is exercised once per builtin Kind: the fix must short-circuit before
-// any type-specific mapper decode runs (a required bool field, for example,
-// would otherwise try to decode "" through boolMapper and fail with a
-// confusing "bool value must be true, 1, ..." error instead of a plain
-// "required" one).
 func TestRequiredFlagWithDefault(t *testing.T) {
-	// assert.Contains(err.Error(), "missing flags") rather than a bare
-	// assert.Error: some builtin mappers (bool, int, float, duration) fail
-	// to decode "" on their own regardless of the fix, which would make a
-	// bare assert.Error pass for the wrong reason (a decode error, not the
-	// required check) and mask a regression in the fix itself.
 	t.Run("string", func(t *testing.T) {
 		var cli struct {
 			Flag string `required:"" default:"${var_flag}"`


### PR DESCRIPTION
Not sure how you want to handle this situation but, test cases + a potential fix:

HasDefault is computed once in hydrateTag from the raw, uninterpolated tag string, so a default like "${var}" looks non-empty even when var is unset. checkMissingFlags only checks flag.Set, and Value.Parse sets Set = true unconditionally when applying a default - so a required field whose ${var}-templated default resolves to "" was silently treated as satisfied instead of missing.

Recompute HasDefault in interpolateValue once Default is actually resolved, after both Default and Enum have been interpolated. Skip the demotion when "" is itself a declared enum member (enum:"one,two,") since that's a legitimate, deliberately-chosen value rather than a missing one.