### PR TITLE
Fix filecontent mapper panicking on a non-[]byte target

### DIFF
--- a/mapper.go
+++ b/mapper.go
@@ -717,7 +717,7 @@ func existingDirMapper(r *Registry) MapperFunc {
 
 func fileContentMapper(r *Registry) MapperFunc {
 	return func(ctx *DecodeContext, target reflect.Value) error {
-		if target.Kind() != reflect.Slice && target.Elem().Kind() != reflect.Uint8 {
+		if target.Kind() != reflect.Slice || target.Type().Elem().Kind() != reflect.Uint8 {
 			return fmt.Errorf("\"filecontent\" must be applied to []byte not %s", target.Type())
 		}
 		var path string

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -510,6 +510,28 @@ func TestFileContentMapper(t *testing.T) {
 	assert.Contains(t, err.Error(), "is a directory")
 }
 
+func TestFileContentMapperRejectsNonByteSlice(t *testing.T) {
+	// A non-[]byte target must return the mapper's validation error, not panic.
+	t.Run("string", func(t *testing.T) {
+		var cli struct {
+			File string `type:"filecontent"`
+		}
+		p := mustNew(t, &cli)
+		_, err := p.Parse([]string{"--file", "testdata/file.txt"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), `"filecontent" must be applied to []byte not string`)
+	})
+	t.Run("string slice", func(t *testing.T) {
+		var cli struct {
+			File []string `type:"filecontent"`
+		}
+		p := mustNew(t, &cli)
+		_, err := p.Parse([]string{"--file", "testdata/file.txt"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), `"filecontent" must be applied to []byte not []string`)
+	})
+}
+
 func TestPathMapperUsingStringPointer(t *testing.T) {
 	type CLI struct {
 		Path *string `type:"path"`


### PR DESCRIPTION
### Problem

`type:"filecontent"` on a field that isn't `[]byte` panics with an opaque `reflect` error at parse time, instead of the mapper's own "must be applied to []byte" validation error:

```go
var cli struct { F string `type:"filecontent"` }
kong.Parse(&cli, ...)   // panics: reflect: call of reflect.Value.Elem on string Value

var cli2 struct { F []string `type:"filecontent"` }
kong.Parse(&cli2, ...)  // panics: reflect.Value.SetBytes of non-byte slice
```

### Cause

The guard in `fileContentMapper` (`mapper.go`) has two defects on one line:

```go
if target.Kind() != reflect.Slice && target.Elem().Kind() != reflect.Uint8 {
```

- `&&` should be `||`: a slice with a non-byte element makes the first operand false, short-circuits, skips the error, and falls through to `SetBytes` on a non-byte slice.
- `target.Elem()` should be `target.Type().Elem()`: `reflect.Value.Elem()` panics on a scalar `Kind` like `string`.

The sibling mappers (`path`, `existingfile`, `existingdir`) validate their target kind correctly and return a clean error; `filecontent` was the only one that panicked.

### Fix

```go
if target.Kind() != reflect.Slice || target.Type().Elem().Kind() != reflect.Uint8 {
```

Now both misuse cases return the intended `--f: "filecontent" must be applied to []byte not <type>` error, and the `[]byte` case is unchanged. Added `TestFileContentMapperRejectsNonByteSlice` (string + []string). `go test ./...` passes; `golangci-lint run ./...` is clean; `gofmt` clean.

This only hardens the guard — it does not add the string support requested in #482; that remains a separate feature decision.

---

*Disclosure: found, written and verified by an AI coding agent (Claude Code) running on this account — it wrote the repro, ran it, and produced this description from running the code, not reading it. I review every change and am accountable for it. Happy to adjust anything.*
