### PR TITLE
Fix counter panic on a uint or float field with an explicit --flag=N

### DIFF
--- a/mapper.go
+++ b/mapper.go
@@ -794,19 +794,32 @@ func counterMapper() MapperFunc {
 			if err != nil {
 				return err
 			}
+			var n int64
 			switch v := t.Value.(type) {
 			case string:
-				n, err := strconv.ParseInt(v, 10, 64)
+				n, err = strconv.ParseInt(v, 10, 64)
 				if err != nil {
 					return fmt.Errorf("expected a counter but got %q (%T)", t, t.Value)
 				}
-				target.SetInt(n)
 
 			case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-				target.Set(reflect.ValueOf(v))
+				n = reflect.ValueOf(v).Convert(reflect.TypeOf(int64(0))).Int()
 
 			default:
 				return fmt.Errorf("expected a counter but got %q (%T)", t, t.Value)
+			}
+
+			// Assign by the target's kind, like the increment path below, so a
+			// counter declared as a uint or float field doesn't panic.
+			switch target.Kind() {
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+				target.SetInt(n)
+			case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+				target.SetUint(uint64(n)) //nolint:gosec // a counter value is small and non-negative
+			case reflect.Float32, reflect.Float64:
+				target.SetFloat(float64(n))
+			default:
+				return fmt.Errorf("type:\"counter\" must be used with a numeric field")
 			}
 			return nil
 		}

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -332,6 +332,16 @@ func TestCounter(t *testing.T) {
 	_, err = p.Parse([]string{"-fff"})
 	assert.NoError(t, err)
 	assert.Equal(t, 3., cli.Float)
+
+	// Explicit --long=N on a uint or float counter must not panic (only the
+	// int field was covered before; uint/float went through SetInt).
+	_, err = p.Parse([]string{"--uint=5"})
+	assert.NoError(t, err)
+	assert.Equal(t, uint(5), cli.Uint)
+
+	_, err = p.Parse([]string{"--float=5"})
+	assert.NoError(t, err)
+	assert.Equal(t, 5., cli.Float)
 }
 
 func TestNumbers(t *testing.T) {


### PR DESCRIPTION
### Problem

A `counter` flag with an explicit value (`--flag=N`, the documented long form) **panics** when the field is a `uint` or `float`:

```go
var cli struct {
    Count uint `type:"counter"`
}
kong.Parse(&cli, "--count=3")
// panic: reflect: call of reflect.Value.SetInt on uint Value
```

The README says `counter` works on a "numeric field" and "Can accept `-s`, `--long` or `--long=N`", and the plain increment form (`-ccc`) already works on `uint`/`float` fields — only the explicit-value form crashes.

### Cause

In `counterMapper`, the increment path switches on `Int`/`Uint`/`Float` kinds, but the explicit-value path assigned unconditionally:

```go
case string:
    n, err := strconv.ParseInt(v, 10, 64)
    ...
    target.SetInt(n)            // panics on a uint/float target
case int, ...:
    target.Set(reflect.ValueOf(v))   // panics on a kind mismatch (e.g. int value, uint target)
```

`SetInt` is only valid on int kinds, so a `uint`/`float64` counter panics. The resolver-supplied numeric branch had the same kind-mismatch issue.

### Fix

Parse the explicit value to an `int64`, then assign by the target's kind (`SetInt`/`SetUint`/`SetFloat`), mirroring the increment path just below it. Extended `TestCounter` with the previously-missing `--uint=N` / `--float=N` cases (it only covered `--int=5` explicitly).

`go test ./...` passes; `golangci-lint`/`gofmt` clean.

---

*Disclosure: authored by an AI coding agent (Claude Code) running on this account — it found the bug, wrote the repro/test, the fix and this description. I review every change and am accountable for it; the verification above is real and re-runnable from the diff. Happy to adjust anything.*
