### PR TITLE
fix: report single-member required xor groups as missing

### DIFF
--- a/context.go
+++ b/context.go
@@ -948,7 +948,10 @@ func checkMissingFlags(flags []*Flag) error {
 		}
 	}
 	for xor, flags := range xorGroup {
-		if !xorGroupSet[xor] && len(flags) > 1 {
+		// Report a required xor group even when only one member is tagged
+		// required (e.g. required A xor B where B is optional). Previously
+		// len(flags) > 1 hid the single required alternative (#516).
+		if !xorGroupSet[xor] && len(flags) >= 1 {
 			missing = append(missing, strings.Join(flags, " or "))
 		}
 	}

--- a/kong_test.go
+++ b/kong_test.go
@@ -2907,3 +2907,31 @@ func TestParseHyphenParameter(t *testing.T) {
 		assert.Equal(t, &shortFlag{Numeric: -10}, actual)
 	})
 }
+
+func TestXorAndRequiredIssue516(t *testing.T) {
+	var cli struct {
+		Hello string `xor:"hello" required:""`
+		One   string `xor:"hello" and:"two"`
+		Two   string `and:"two"`
+	}
+
+	// Empty input must fail: the required xor group is not satisfied.
+	p := mustNew(t, &cli)
+	_, err := p.Parse([]string{})
+	assert.EqualError(t, err, "missing flags: --hello=STRING")
+
+	// Selecting the optional xor alternative alone still fails the and-group.
+	p = mustNew(t, &cli)
+	_, err = p.Parse([]string{"--one=a"})
+	assert.EqualError(t, err, "--one and --two must be used together")
+
+	// one+two satisfies the required xor group without --hello.
+	p = mustNew(t, &cli)
+	_, err = p.Parse([]string{"--one=a", "--two=b"})
+	assert.NoError(t, err)
+
+	// hello alone satisfies required xor and does not need the and-group.
+	p = mustNew(t, &cli)
+	_, err = p.Parse([]string{"--hello=x"})
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
When a required flag is in an xor group with optional alternatives, an empty parse previously reported no missing flags if the group only contributed a single required summary (`len(flags) > 1` gate).

That made cases like:

```go
Hello string `xor:"hello" required:""`
One   string `xor:"hello" and:"two"`
Two   string `and:"two"`
```

accept `Parse([]string{})` without error (#516).

## Fix
In `checkMissingFlags`, report required xor groups when no member is set even if only one required summary is present (`len(flags) >= 1`).

## Test plan
- [x] `go test .`
- [x] New `TestXorAndRequiredIssue516`
- [x] Existing xor/and required tests still pass

Fixes #516
