### PR TITLE
Validate flags/positionals before the commands/nodes that own them

### DIFF
--- a/context.go
+++ b/context.go
@@ -204,7 +204,7 @@ func (c *Context) Validate() error { //nolint: gocyclo
 			}
 		}
 	}
-	for _, el := range c.Path {
+	validateEl := func(el *Path) error {
 		var (
 			value reflect.Value
 			desc  string
@@ -234,6 +234,42 @@ func (c *Context) Validate() error { //nolint: gocyclo
 				return err
 			}
 		}
+		return nil
+	}
+	// Each command/node's own flags and positionals are validated immediately
+	// before that command/node itself, so its Validate() runs against
+	// already-validated flag values rather than raw input. A node's own
+	// flags/positionals appear right after it on the path, so its validation
+	// is deferred until the next node boundary (or the end of the path),
+	// preserving the original relative order between different nodes.
+	//
+	// Note: Resolve() appends resolver-derived flag values to the end of
+	// c.Path without recording which node each one belongs to, so a node
+	// whose own resolved (not command-line-supplied) flags come from a
+	// Resolver can end up deferred past other nodes' resolved flags too.
+	var pendingNode *Path
+	flushPendingNode := func() error {
+		if pendingNode == nil {
+			return nil
+		}
+		node := pendingNode
+		pendingNode = nil
+		return validateEl(node)
+	}
+	for _, el := range c.Path {
+		if el.Flag != nil || el.Positional != nil {
+			if err := validateEl(el); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := flushPendingNode(); err != nil {
+			return err
+		}
+		pendingNode = el
+	}
+	if err := flushPendingNode(); err != nil {
+		return err
 	}
 	for _, resolver := range c.combineResolvers() {
 		if err := resolver.Validate(c.Model); err != nil {

--- a/context.go
+++ b/context.go
@@ -205,71 +205,7 @@ func (c *Context) Validate() error { //nolint: gocyclo
 			}
 		}
 	}
-	validateEl := func(el *Path) error {
-		var (
-			value reflect.Value
-			desc  string
-		)
-		switch node := el.Visitable().(type) {
-		case *Value:
-			value = node.Target
-			desc = node.ShortSummary()
-
-		case *Flag:
-			value = node.Target
-			desc = node.ShortSummary()
-
-		case *Application:
-			value = node.Target
-			desc = ""
-
-		case *Node:
-			value = node.Target
-			desc = node.Path()
-		}
-		for _, validate := range getValidators(value) {
-			if err := validate.Validate(c); err != nil {
-				if desc != "" {
-					return fmt.Errorf("%s: %w", desc, err)
-				}
-				return err
-			}
-		}
-		return nil
-	}
-	// Each command/node's own flags and positionals are validated immediately
-	// before that command/node itself, so its Validate() runs against
-	// already-validated flag values rather than raw input. A node's own
-	// flags/positionals appear right after it on the path, so its validation
-	// is deferred until the next node boundary (or the end of the path),
-	// preserving the original relative order between different nodes.
-	//
-	// Note: Resolve() appends resolver-derived flag values to the end of
-	// c.Path without recording which node each one belongs to, so a node
-	// whose own resolved (not command-line-supplied) flags come from a
-	// Resolver can end up deferred past other nodes' resolved flags too.
-	var pendingNode *Path
-	flushPendingNode := func() error {
-		if pendingNode == nil {
-			return nil
-		}
-		node := pendingNode
-		pendingNode = nil
-		return validateEl(node)
-	}
-	for _, el := range c.Path {
-		if el.Flag != nil || el.Positional != nil {
-			if err := validateEl(el); err != nil {
-				return err
-			}
-			continue
-		}
-		if err := flushPendingNode(); err != nil {
-			return err
-		}
-		pendingNode = el
-	}
-	if err := flushPendingNode(); err != nil {
+	if err := c.validatePathValues(); err != nil {
 		return err
 	}
 	for _, resolver := range c.combineResolvers() {
@@ -323,6 +259,99 @@ func (c *Context) Validate() error { //nolint: gocyclo
 		value := node.Argument
 		if value.Required && !value.Set {
 			return fmt.Errorf("%s is required", node.Summary())
+		}
+	}
+	return nil
+}
+
+// validatePathValues runs each path element's Validate() hooks. A node's hook
+// must run after its own flags and positionals. Because a flag can be supplied
+// after a descendant command, each is mapped to its owning node and a node is
+// deferred until none of its values are still outstanding.
+func (c *Context) validatePathValues() error {
+	flagOwner := map[*Flag]*Node{}
+	for _, el := range c.Path {
+		for _, flag := range el.Flags {
+			flagOwner[flag] = el.Node()
+		}
+	}
+	outstanding := map[*Node]int{}
+	for _, el := range c.Path {
+		switch {
+		case el.Flag != nil:
+			if owner := flagOwner[el.Flag]; owner != nil {
+				outstanding[owner]++
+			}
+		case el.Positional != nil:
+			outstanding[el.Parent]++
+		}
+	}
+	// Nodes flush in path order, so a parent still precedes its child.
+	var pending []*Path
+	flushReady := func() error {
+		for len(pending) > 0 && outstanding[pending[0].Node()] == 0 {
+			node := pending[0]
+			pending = pending[1:]
+			if err := c.validateValue(node); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for _, el := range c.Path {
+		switch {
+		case el.Flag != nil:
+			if err := c.validateValue(el); err != nil {
+				return err
+			}
+			if owner := flagOwner[el.Flag]; owner != nil {
+				outstanding[owner]--
+			}
+		case el.Positional != nil:
+			if err := c.validateValue(el); err != nil {
+				return err
+			}
+			outstanding[el.Parent]--
+		default:
+			if err := flushReady(); err != nil {
+				return err
+			}
+			pending = append(pending, el)
+		}
+	}
+	return flushReady()
+}
+
+// validateValue runs the user-defined Validate() hooks bound to a single path
+// element (a flag, positional, node or the application).
+func (c *Context) validateValue(el *Path) error {
+	var (
+		value reflect.Value
+		desc  string
+	)
+	switch node := el.Visitable().(type) {
+	case *Value:
+		value = node.Target
+		desc = node.ShortSummary()
+
+	case *Flag:
+		value = node.Target
+		desc = node.ShortSummary()
+
+	case *Application:
+		value = node.Target
+		desc = ""
+
+	case *Node:
+		value = node.Target
+		desc = node.Path()
+	}
+	for _, validate := range getValidators(value) {
+		if err := validate.Validate(c); err != nil {
+			if desc != "" {
+				return fmt.Errorf("%s: %w", desc, err)
+			}
+			return err
 		}
 	}
 	return nil

--- a/kong_test.go
+++ b/kong_test.go
@@ -1618,6 +1618,63 @@ func TestValidateCmd(t *testing.T) {
 	assert.EqualError(t, err, "cmd: cmd error")
 }
 
+var validateOrderLog []string
+
+type validateOrderCmd struct {
+	Flag validateOrderFlag
+}
+
+func (v *validateOrderCmd) Validate() error {
+	validateOrderLog = append(validateOrderLog, "cmd")
+	return nil
+}
+
+type validateOrderFlag string
+
+func (v *validateOrderFlag) Validate() error {
+	validateOrderLog = append(validateOrderLog, "flag")
+	return nil
+}
+
+// A command's Validate() should run against already-validated flag values,
+// so its own flags must be validated first.
+func TestValidateCmdRunsAfterItsFlags(t *testing.T) {
+	validateOrderLog = nil
+	cli := struct {
+		Cmd validateOrderCmd `cmd:""`
+	}{}
+	p := mustNew(t, &cli)
+	_, err := p.Parse([]string{"cmd", "--flag=value"})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"flag", "cmd"}, validateOrderLog)
+}
+
+type validateOrderParent struct {
+	ParentFlag validateOrderFlag
+	Cmd        validateOrderCmd `cmd:""`
+}
+
+func (v *validateOrderParent) Validate() error {
+	validateOrderLog = append(validateOrderLog, "parent")
+	return nil
+}
+
+// Each command's own flags validate immediately before it, and the relative
+// order between different commands on the path (app before parent before
+// cmd) is unaffected - a command's own flags don't get held back by an
+// unrelated descendant command's flags, or vice versa.
+func TestValidateNestedCmdRunsAfterOwnFlagsOnly(t *testing.T) {
+	validateOrderLog = nil
+	cli := struct {
+		AppFlag validateOrderFlag
+		Parent  validateOrderParent `cmd:""`
+	}{}
+	p := mustNew(t, &cli)
+	_, err := p.Parse([]string{"--app-flag=a", "parent", "--parent-flag=b", "cmd", "--flag=c"})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"flag", "flag", "parent", "flag", "cmd"}, validateOrderLog)
+}
+
 func TestValidateFlag(t *testing.T) {
 	cli := struct {
 		Flag validateFlag

--- a/kong_test.go
+++ b/kong_test.go
@@ -1808,6 +1808,21 @@ func TestValidateNestedCmdRunsAfterOwnFlagsOnly(t *testing.T) {
 	assert.Equal(t, []string{"flag", "flag", "parent", "flag", "cmd"}, validateOrderLog)
 }
 
+// An ancestor's flag may be supplied after a descendant command on the command
+// line (e.g. "parent cmd --parent-flag=b"), which puts it after the descendant
+// on the path. The ancestor's Validate() must still run after its own flag, not
+// before it.
+func TestValidateCmdRunsAfterOwnFlagSuppliedAfterSubcommand(t *testing.T) {
+	validateOrderLog = nil
+	cli := struct {
+		Parent validateOrderParent `cmd:""`
+	}{}
+	p := mustNew(t, &cli)
+	_, err := p.Parse([]string{"parent", "cmd", "--parent-flag=b"})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"flag", "parent", "cmd"}, validateOrderLog)
+}
+
 func TestValidateFlag(t *testing.T) {
 	cli := struct {
 		Flag validateFlag


### PR DESCRIPTION
Fixes #611.

## Bug

`Context.Validate()` iterates `c.Path` in trace order and calls each element's `Validate()` as it's encountered. Since a command's own `Path` entry is appended before its flags' entries (flags come later in the token stream, e.g. `command --flag value`), the command's `Validate()` ran before its flags' `Validate()` — so a command's validator couldn't rely on its own flags already being validated:

```go
kong.Must(&CLI{}).Parse([]string{"command", "--flag", "value"})
// validate command   <- ran first
// validate flag       <- should have run first
```

## Fix

A node's own flags/positionals always appear on the path contiguously right after that node, before the next node entry. So each node's own validation is now deferred (via a single `pendingNode` variable) until that boundary — or the end of the path — is reached, running it right after its own flags/positionals instead of before them.

This only reorders each node relative to its *own* directly-owned flags. The relative order between different nodes on the path is unaffected — a parent command still validates before its child command, exactly as before. (An earlier version of this fix used a flat two-pass split over the whole path instead, which had a wider side effect: an ancestor command's validation could get delayed by an unrelated descendant command's flags. This version avoids that by only ever holding back the *most recently encountered* node, not the whole path.)

## Known limitation

`Resolve()` appends resolver-derived flag values (e.g. from a config-file `Resolver`) to the end of `c.Path` without recording which node each one belongs to. Because of that, a node whose flags come from a `Resolver` (rather than the command line) can still end up deferred past *other* nodes' resolver-supplied flags too — noted in a code comment. Fixing this properly would mean also threading ownership through `Resolve()`'s appended entries, which felt like more than this fix should take on; happy to follow up separately if that's worth doing.

## Tests

- `TestValidateCmdRunsAfterItsFlags` — the issue's exact repro (single command, one flag).
- `TestValidateNestedCmdRunsAfterOwnFlagsOnly` — two-level nesting (app flag, parent command + its own flag, child command + its own flag), confirming each level's own flag validates immediately before it while app → parent → child ordering is preserved.

Both confirmed to fail against pre-fix code and pass with the fix.
