### PR TITLE
fix: allow config to override invalid defaults

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -39,6 +39,32 @@ func TestConfigValidation(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestConfigOverridesInvalidDefaultForExistingFile(t *testing.T) {
+	var cli struct {
+		Path string `json:"path" default:"missing-file" type:"existingfile"`
+	}
+
+	existingFile := t.TempDir() + "/configured-file"
+	assert.NoError(t, os.WriteFile(existingFile, nil, 0o600))
+	config := makeConfig(t, map[string]string{"path": existingFile})
+
+	p := mustNew(t, &cli, kong.Configuration(kong.JSON, config))
+	_, err := p.Parse(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, existingFile, cli.Path)
+}
+
+func TestConfigDoesNotMaskInvalidDefaultWithoutOverride(t *testing.T) {
+	var cli struct {
+		Path string `json:"path" default:"missing-file" type:"existingfile"`
+	}
+
+	config := makeConfig(t, map[string]string{"other": "value"})
+	p := mustNew(t, &cli, kong.Configuration(kong.JSON, config))
+	_, err := p.Parse(nil)
+	assert.Error(t, err)
+}
+
 func makeConfig(t *testing.T, config any) (path string) {
 	t.Helper()
 	w, err := os.CreateTemp(t.TempDir(), "")

--- a/context.go
+++ b/context.go
@@ -87,10 +87,11 @@ type Context struct {
 	// Error that occurred during trace, if any.
 	Error error
 
-	values    map[*Value]reflect.Value // Temporary values during tracing.
-	bindings  bindings
-	resolvers []Resolver // Extra context-specific resolvers.
-	scan      *Scanner
+	values      map[*Value]reflect.Value // Temporary values during tracing.
+	resetErrors map[*Value]error         // Default errors that a resolver may override.
+	bindings    bindings
+	resolvers   []Resolver // Extra context-specific resolvers.
+	scan        *Scanner
 }
 
 // Trace path of "args" through the grammar tree.
@@ -344,6 +345,7 @@ func (c *Context) FlagValue(flag *Flag) any {
 // Reset recursively resets values to defaults (as specified in the grammar) or the zero value.
 func (c *Context) Reset() error {
 	selected := c.selectedValues()
+	c.resetErrors = map[*Value]error{}
 	return Visit(c.Model.Node, func(node Visitable, next Next) error {
 		value, ok := node.(*Value)
 		if !ok {
@@ -354,6 +356,12 @@ func (c *Context) Reset() error {
 			// An envar shared with a node outside the selected command path
 			// may not parse there; that must not fail this parse.
 			value.Target.Set(reflect.Zero(value.Target.Type()))
+			err = nil
+		}
+		if err != nil && len(c.combineResolvers()) != 0 {
+			// A resolver may supply a valid value after defaults are reset.
+			// Keep the error so Resolve can return it if no value overrides it.
+			c.resetErrors[value] = err
 			err = nil
 		}
 		return next(err)
@@ -654,6 +662,11 @@ func (c *Context) Resolve() error {
 		}
 	}
 	c.Path = append(c.Path, inserted...)
+	for value, err := range c.resetErrors {
+		if _, ok := c.values[value]; !ok {
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Fixes #454

An invalid default is evaluated during reset before configuration resolvers run. That prevented a valid configuration value from replacing the default.

This defers the reset error while resolvers are present, then returns it after resolution only when no resolver supplied a value.

Tests:
- configuration overrides an invalid existing-file default
- configuration without an override still returns the default validation error
- `go test ./...`