### PR TITLE
Propagate envprefix to subcommand flags

### DIFF
--- a/build.go
+++ b/build.go
@@ -248,7 +248,9 @@ func validatePositionalArguments(node *Node) error {
 }
 
 func buildChild(k *Kong, node *Node, typ NodeType, v reflect.Value, ft reflect.StructField, fv reflect.Value, tag *Tag, name string, seenFlags map[string]bool) error {
-	child, err := buildNode(k, fv, typ, newEmptyTag(), seenFlags)
+	childTag := newEmptyTag()
+	childTag.EnvPrefix = tag.EnvPrefix
+	child, err := buildNode(k, fv, typ, childTag, seenFlags)
 	if err != nil {
 		return err
 	}

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -135,6 +135,24 @@ func TestEnvarsNestedEnvPrefix(t *testing.T) {
 	assert.Equal(t, "abc", cli.String)
 }
 
+func TestEnvarsEnvPrefixOnSubcommand(t *testing.T) {
+	type CmdCLI struct {
+		InnerFlag string `env:"INNER_FLAG"`
+	}
+	type TestCLI struct {
+		TopFlag string `env:"TOP_FLAG"`
+		Cmd     CmdCLI `cmd:"" envprefix:"CMD_"`
+	}
+	var cli struct {
+		TestCLI `envprefix:"APP_"`
+	}
+	parser := newEnvParser(t, &cli, envMap{"APP_CMD_INNER_FLAG": "abc"})
+
+	_, err := parser.Parse([]string{"cmd"})
+	assert.NoError(t, err)
+	assert.Equal(t, "abc", cli.Cmd.InnerFlag)
+}
+
 func TestEnvarsWithDefault(t *testing.T) {
 	var cli struct {
 		Flag string `env:"KONG_FLAG" default:"default"`


### PR DESCRIPTION
Fixes #541

## Reproduction

A command nested under an embedded struct loses the accumulated `envprefix` when resolving environment variables for flags inside that command:

```go
type CmdCLI struct {
    InnerFlag string `env:"INNER_FLAG"`
}
type TestCLI struct {
    Cmd CmdCLI `cmd:"" envprefix:"CMD_"`
}
var cli struct {
    TestCLI `envprefix:"APP_"`
}
```

With `APP_CMD_INNER_FLAG=abc`, parsing `cmd` should set `cli.Cmd.InnerFlag`, but it remained empty. The new `TestEnvarsEnvPrefixOnSubcommand` regression test fails on the previous implementation and passes with this change.

## Root cause

`buildChild()` built subcommand nodes with a fresh empty tag, so `flattenedFields()` inside the child had no parent `EnvPrefix` to prepend to child flag `env` tags.

## Fix

Carry the accumulated `EnvPrefix` from the command field's tag into the child node build tag before building the subcommand's fields. This keeps existing flag names and command metadata unchanged while allowing command-local `envprefix` tags to compose with enclosing embedded prefixes.

## Compatibility

This only affects environment-variable names generated for flags inside subcommands that declare or inherit `envprefix`. Existing explicit `env` names without a command/environment prefix are unchanged.

## Validation

- `go test ./... -run TestEnvarsEnvPrefixOnSubcommand -count=1` fails without the fix and passes with it.
- `go build ./...` passes.
- `gofmt -l .` is empty.
- `go test ./...` passes.
- `go vet ./...` currently reports pre-existing bare Kong test struct tags as bad struct tags under Go 1.26.5; this PR does not add any such tags.