### PR TITLE
Fix single-character alias leaking between sibling commands

### DIFF
--- a/build.go
+++ b/build.go
@@ -214,7 +214,11 @@ MAIN:
 			delete(seenFlags, negFlag)
 		}
 		for _, aflag := range flag.Aliases {
-			delete(seenFlags, "--"+aflag)
+			if utf8.RuneCountInString(aflag) == 1 {
+				delete(seenFlags, "-"+aflag)
+			} else {
+				delete(seenFlags, "--"+aflag)
+			}
 		}
 	}
 

--- a/kong_test.go
+++ b/kong_test.go
@@ -1823,6 +1823,23 @@ func TestSubCommandAliases(t *testing.T) {
 	assert.NoError(t, err, "dupe aliases shouldn't error if they're in separate sub commands")
 }
 
+func TestSubCommandSingleCharAliases(t *testing.T) {
+	type SubC struct {
+		Flag1 string `aliases:"f"`
+	}
+
+	cli1 := struct {
+		Sub1 SubC `cmd:"" name:"sub1"`
+		Sub2 SubC `cmd:"" name:"sub2"`
+	}{}
+
+	app, err := kong.New(&cli1)
+	assert.NoError(t, err, "dupe single-character aliases shouldn't error if they're in separate sub commands")
+	_, err = app.Parse([]string{"sub2", "-f", "hello"})
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", cli1.Sub2.Flag1)
+}
+
 func TestDuplicateAliasLong(t *testing.T) {
 	cli2 := struct {
 		Flag  string ``


### PR DESCRIPTION
Two sibling commands that each carry a flag with `aliases:"f"`:

```go
type SubC struct {
	Flag1 string `aliases:"f"`
}
cli := struct {
	Sub1 SubC `cmd:"" name:"sub1"`
	Sub2 SubC `cmd:"" name:"sub2"`
}{}
```

fail to build:

```
SubC.Flag1: duplicate flag -f
```

The same grammar with `aliases:"ff"` or `short:"f"` builds fine.

Since single-character aliases became short flags in v1.16.0, `buildField` registers them in `seenFlags` as `-f`, but the "unsee" loop in `buildNode` that releases a node's flags for its siblings still only deletes `--f`, so the alias stays seen. The `short:` case a few lines above is unseen correctly, which is the asymmetry. The fix mirrors `buildField`'s rune-count test when unseeing an alias.

`TestSubCommandSingleCharAliases` is the single-character counterpart of the existing `TestSubCommandAliases`; I checked it fails with the error above when the `build.go` hunk is reverted. `go test ./...` and `golangci-lint run` are clean locally.
