### PR TITLE
Fix disabled DefaultEnvars help suffix

### DIFF
--- a/help_test.go
+++ b/help_test.go
@@ -471,6 +471,18 @@ func TestEnvarAutoHelp(t *testing.T) {
 	assert.Contains(t, w.String(), "A flag ($FLAG).")
 }
 
+func TestDisabledDefaultEnvarAutoHelp(t *testing.T) {
+	var cli struct {
+		Flag string `env:"-" help:"A flag."`
+	}
+	w := &strings.Builder{}
+	p := mustNew(t, &cli, kong.DefaultEnvars("KONG"), kong.Writers(w, w), kong.Exit(func(int) {}))
+	_, err := p.Parse([]string{"--help"})
+	assert.NoError(t, err)
+	assert.Contains(t, w.String(), "A flag.")
+	assert.NotContains(t, w.String(), "($-)")
+}
+
 func TestMultipleEnvarAutoHelp(t *testing.T) {
 	var cli struct {
 		Flag string `env:"FLAG1,FLAG2" help:"A flag."`

--- a/options.go
+++ b/options.go
@@ -529,6 +529,7 @@ func DefaultEnvars(prefix string) Option {
 			return
 		case len(env) == 1 && env[0] == "-":
 			flag.Envs = nil
+			flag.Value.Tag.Envs = nil
 			return
 		case len(env) > 0:
 			return


### PR DESCRIPTION
Fixes #636.

`DefaultEnvars` cleared `Flag.Envs` for `env:"-"` but left the marker in `Value.Tag.Envs`, which help formatting uses. Clear both representations and cover the generated help with a regression test.

Tests:
- `go test ./... -run '^TestDisabledDefaultEnvarAutoHelp$' -count=1`
- `go test ./... -run 'EnvarAutoHelp|^TestEnv$|^TestEnvars' -count=1`
- `go test ./...`
- `golangci-lint run --new-from-rev=HEAD`
