### PR TITLE
fix: DefaultEnvars no longer shows ($-) in help for env:"-" flags

### DIFF
--- a/help_test.go
+++ b/help_test.go
@@ -973,3 +973,14 @@ Flags:
 	t.Log(w.String())
 	assert.Equal(t, expected, w.String())
 }
+
+func TestEnvarAutoHelpWithEnvDash(t *testing.T) {
+	var cli struct {
+		Flag string `env:"-" help:"A flag."`
+	}
+	w := &strings.Builder{}
+	p := mustNew(t, &cli, kong.DefaultEnvars("KONG"), kong.Writers(w, w), kong.Exit(func(int) {}))
+	_, err := p.Parse([]string{"--help"})
+	assert.NoError(t, err)
+	assert.NotContains(t, w.String(), "($-)")
+}

--- a/options.go
+++ b/options.go
@@ -529,6 +529,7 @@ func DefaultEnvars(prefix string) Option {
 			return
 		case len(env) == 1 && env[0] == "-":
 			flag.Envs = nil
+			flag.Value.Tag.Envs = nil
 			return
 		case len(env) > 0:
 			return


### PR DESCRIPTION
Fixes #636.

Root cause: since v1.16.0 the env sync direction in `interpolateValue` flipped (`value.Flag.Envs = value.Tag.Envs` instead of the old `value.Tag.Envs = value.Flag.Envs`). `DefaultEnvars` special-cases the `env:"-"` sentinel by clearing only `value.Flag.Envs`; `value.Tag.Envs` still holds `"-"` and the help formatter renders from `value.Tag.Envs` → help shows `($-)`.

Also clears `value.Tag.Envs` in the dash case, restoring v1.15 behavior.

Regression test `TestEnvarAutoHelpWithEnvDash` added. Full suite: `go test ./...` passes.