### PR TITLE
fix: place [flags] before passthrough args in summaries

### DIFF
--- a/help_test.go
+++ b/help_test.go
@@ -985,3 +985,15 @@ Flags:
 	t.Log(w.String())
 	assert.Equal(t, expected, w.String())
 }
+
+func TestHelpPassthroughArgsFlagsPosition(t *testing.T) {
+	var cli struct {
+		Flag string
+		Args []string `arg:"" optional:"" passthrough:""`
+	}
+	w := &strings.Builder{}
+	p := mustNew(t, &cli, kong.Writers(w, w), kong.Exit(func(int) {}))
+	_, err := p.Parse([]string{"--help"})
+	assert.NoError(t, err)
+	assert.Contains(t, w.String(), "Usage: test [flags] [<args> ...]")
+}

--- a/model.go
+++ b/model.go
@@ -161,6 +161,32 @@ func (n *Node) Summary() string {
 	if flags := n.FlagSummary(true); flags != "" {
 		summary += " " + flags
 	}
+	allFlags := n.Flags
+	if n.Parent != nil {
+		allFlags = append(allFlags, n.Parent.Flags...)
+	}
+	hasFlags := false
+	for _, flag := range allFlags {
+		if _, ok := flag.Target.Interface().(helpFlag); ok {
+			continue
+		}
+		if !flag.Required {
+			hasFlags = true
+			break
+		}
+	}
+	passthrough := n.Passthrough
+	if !passthrough {
+		for _, arg := range n.Positional {
+			if arg.Passthrough {
+				passthrough = true
+				break
+			}
+		}
+	}
+	if hasFlags && passthrough {
+		summary += " [flags]"
+	}
 	args := []string{}
 	optional := 0
 	for _, arg := range n.Positional {
@@ -176,18 +202,8 @@ func (n *Node) Summary() string {
 	} else if len(n.Children) > 0 {
 		summary += " <command>"
 	}
-	allFlags := n.Flags
-	if n.Parent != nil {
-		allFlags = append(allFlags, n.Parent.Flags...)
-	}
-	for _, flag := range allFlags {
-		if _, ok := flag.Target.Interface().(helpFlag); ok {
-			continue
-		}
-		if !flag.Required {
-			summary += " [flags]"
-			break
-		}
+	if hasFlags && !passthrough {
+		summary += " [flags]"
 	}
 	return summary
 }

--- a/model_test.go
+++ b/model_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
+	"github.com/alecthomas/kong"
 )
 
 func TestModelApplicationCommands(t *testing.T) {
@@ -89,4 +90,27 @@ Flags:
   -h, --help          Show context-sensitive help.
       --one=STRING
 `, w.String())
+}
+
+func TestSummaryPassthroughCommand(t *testing.T) {
+	var cli struct {
+		Flag    string
+		Command struct {
+			Args []string `arg:"" optional:""`
+		} `cmd:"" passthrough:""`
+	}
+	k, err := kong.New(&cli)
+	assert.NoError(t, err)
+	cmd := k.Model.Node.Children[0]
+	assert.Equal(t, "command [flags] [<args> ...]", cmd.Summary())
+}
+
+func TestSummaryPassthroughArg(t *testing.T) {
+	var cli struct {
+		Flag string
+		Args []string `arg:"" optional:"" passthrough:""`
+	}
+	k, err := kong.New(&cli)
+	assert.NoError(t, err)
+	assert.Equal(t, " [flags] [<args> ...]", k.Model.Node.Summary())
 }


### PR DESCRIPTION
Fixes #465.

## Problem
For `passthrough` commands/arguments the summary rendered as e.g. `command [<args> ...] [flags]`, implying flags are usable after the passthrough token. Since passthrough consumes everything following it, flags must come first: `command [flags] [<args> ...]`.

## Fix
`Node.Summary()` now detects passthrough (command-level `passthrough` tag or a passthrough positional) and renders `[flags]` before the args/command part. Non-passthrough nodes keep the existing `[flags]`-at-end output, so no golden outputs change.

## Tests
- `TestSummaryPassthroughCommand` / `TestSummaryPassthroughArg` (unit, model level)
- `TestHelpPassthroughArgsFlagsPosition` (help output: `Usage: test [flags] [<args> ...]`)

All verified red before the change, green after. Full suite `go test ./...`, `go vet` (no new warnings) and `golangci-lint` (v1.64.8) pass.