### PR TITLE
fix: JSON resolver now matches camelCase keys in nested (embedded) struct sections

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"io"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 // A Resolver resolves a Flag value from an external source.
@@ -74,9 +76,11 @@ func snakeCase(name string) string {
 func camelize(s string) string {
 	parts := strings.Split(s, "_")
 	for i := 1; i < len(parts); i++ {
-		if parts[i] != "" {
-			parts[i] = strings.ToUpper(parts[i][:1]) + parts[i][1:]
+		if parts[i] == "" {
+			continue
 		}
+		r, size := utf8.DecodeRuneInString(parts[i])
+		parts[i] = string(unicode.ToUpper(r)) + parts[i][size:]
 	}
 	return strings.Join(parts, "")
 }

--- a/resolver.go
+++ b/resolver.go
@@ -47,14 +47,17 @@ func JSON(r io.Reader) (Resolver, error) {
 		}
 		raw = values
 		for _, part := range strings.Split(name, ".") {
-			if values, ok := raw.(map[string]any); ok {
-				raw, ok = values[part]
-				if !ok {
-					return nil, nil
-				}
-			} else {
+			values, ok := raw.(map[string]any)
+			if !ok {
 				return nil, nil
 			}
+			if raw, ok = values[part]; ok {
+				continue
+			}
+			if raw, ok = values[camelize(part)]; ok {
+				continue
+			}
+			return nil, nil
 		}
 		return raw, nil
 	}
@@ -65,4 +68,15 @@ func JSON(r io.Reader) (Resolver, error) {
 func snakeCase(name string) string {
 	name = strings.Join(strings.Split(strings.Title(name), "-"), "") //nolint:staticcheck // Unicode punctuation not an issue
 	return strings.ToLower(name[:1]) + name[1:]
+}
+
+// camelize converts a snake_case segment to camelCase, e.g. "with_camel" -> "withCamel".
+func camelize(s string) string {
+	parts := strings.Split(s, "_")
+	for i := 1; i < len(parts); i++ {
+		if parts[i] != "" {
+			parts[i] = strings.ToUpper(parts[i][:1]) + parts[i][1:]
+		}
+	}
+	return strings.Join(parts, "")
 }

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -280,6 +280,30 @@ func TestEnv(t *testing.T) {
 	assert.Equal(t, expected, cli)
 }
 
+func TestJSONCamelCaseEmbedded(t *testing.T) {
+	type Embed struct {
+		WithCamelCase string
+	}
+
+	var cli struct {
+		Level Embed `prefix:"level." embed:""`
+	}
+
+	json := `{
+		"level": {
+			"withCamelCase": "camel value"
+		}
+	}`
+
+	r, err := kong.JSON(strings.NewReader(json))
+	assert.NoError(t, err)
+
+	parser := mustNew(t, &cli, kong.Resolvers(r))
+	_, err = parser.Parse([]string{})
+	assert.NoError(t, err)
+	assert.Equal(t, "camel value", cli.Level.WithCamelCase)
+}
+
 func TestJSONBasic(t *testing.T) {
 	type Embed struct {
 		String string

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -283,6 +283,7 @@ func TestEnv(t *testing.T) {
 func TestJSONCamelCaseEmbedded(t *testing.T) {
 	type Embed struct {
 		WithCamelCase string
+		WithSnakeCase string
 	}
 
 	var cli struct {
@@ -291,7 +292,8 @@ func TestJSONCamelCaseEmbedded(t *testing.T) {
 
 	json := `{
 		"level": {
-			"withCamelCase": "camel value"
+			"withCamelCase": "camel value",
+			"with_snake_case": "snake value"
 		}
 	}`
 
@@ -302,6 +304,7 @@ func TestJSONCamelCaseEmbedded(t *testing.T) {
 	_, err = parser.Parse([]string{})
 	assert.NoError(t, err)
 	assert.Equal(t, "camel value", cli.Level.WithCamelCase)
+	assert.Equal(t, "snake value", cli.Level.WithSnakeCase)
 }
 
 func TestJSONBasic(t *testing.T) {

--- a/util_test.go
+++ b/util_test.go
@@ -67,3 +67,9 @@ func TestChangeDirFlag(t *testing.T) {
 	}
 	assert.Equal(t, file, cli.Path)
 }
+
+func TestCamelize(t *testing.T) {
+	assert.Equal(t, "withCamelCase", camelize("with_camel_case"))
+	assert.Equal(t, "seviyeÖzellik", camelize("seviye_özellik"))
+	assert.Equal(t, "alreadyCamel", camelize("alreadyCamel"))
+}


### PR DESCRIPTION
Fixes #489 — kong.JSON cannot resolve camelCase keys inside embedded/`prefix:"..."` struct sections.

Root cause: the JSON resolver walks dotted flag names (e.g. `level.with_camel`) section by section, but only looks up the snake_case segment (`with_camel`) in each map level, never its camelCase variant (`withCamel`).

```go
// before
if raw, ok = values[part]; ok { ... }    // only snake_case segment tried
```

Fix: also try the camelCase variant of each dotted segment (new `camelize` helper). Existing snake_case and flat dotted-key lookups are unchanged; duplicate-key style (`{"level":{"withCamel":..}}`) now resolves.

## Testing
- Red: `TestJSONCamelCaseEmbedded` failed before the change (`Level.WithCamelCase` stayed empty).
- Green: full `go test ./...` passes; `go vet`, `gofmt`, `golangci-lint` clean.