### PR TITLE
fix: skip validating I/O mappers' defaults when resolvers may override them

### DIFF
--- a/context.go
+++ b/context.go
@@ -342,14 +342,16 @@ func (c *Context) FlagValue(flag *Flag) any {
 }
 
 // Reset recursively resets values to defaults (as specified in the grammar) or the zero value.
-func (c *Context) Reset() error {
+func (c *Context) Reset() error { return c.reset(false) }
+
+func (c *Context) reset(skipDefaults bool) error {
 	selected := c.selectedValues()
 	return Visit(c.Model.Node, func(node Visitable, next Next) error {
 		value, ok := node.(*Value)
 		if !ok {
 			return next(nil)
 		}
-		err := value.Reset()
+		err := value.reset(skipDefaults)
 		if err != nil && !selected[value] {
 			// An envar shared with a node outside the selected command path
 			// may not parse there; that must not fail this parse.

--- a/kong.go
+++ b/kong.go
@@ -331,7 +331,10 @@ func (k *Kong) Parse(args []string) (ctx *Context, err error) {
 	if err = k.applyHook(ctx, "BeforeReset"); err != nil {
 		return nil, &ParseError{error: err, Context: ctx}
 	}
-	if err = ctx.Reset(); err != nil {
+	// If a resolver or config loader may provide values, defer applying
+	// defaults so that mappers which perform I/O (e.g. existingfile) do not
+	// fail on defaults that will be replaced before use (see #454).
+	if err = ctx.reset(len(k.resolvers) > 0 || k.loader != nil); err != nil {
 		return nil, &ParseError{error: err, Context: ctx}
 	}
 	if err = k.applyHook(ctx, "BeforeResolve"); err != nil {

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -897,3 +897,32 @@ func TestFileMapperWithDefaultNonExistentFile(t *testing.T) {
 	assert.Contains(t, err.Error(), "missing-default.txt")
 	assert.IsError(t, err, os.ErrNotExist)
 }
+
+func TestExistingFileMapperDefaultWithConfigLoader(t *testing.T) {
+	type CLI struct {
+		Path string `type:"existingfile" default:"testdata/missing.txt"`
+	}
+	var cli CLI
+	config := filepath.Join(t.TempDir(), "config.json")
+	err := os.WriteFile(config, []byte(`{"path": "testdata/file.txt"}`), 0o600)
+	assert.NoError(t, err)
+
+	p := mustNew(t, &cli, kong.Configuration(kong.JSON, config))
+	_, err = p.Parse([]string{})
+	assert.NoError(t, err)
+	assert.Contains(t, cli.Path, filepath.Join("testdata", "file.txt"))
+}
+
+func TestExistingFileMapperDefaultWithJSONResolver(t *testing.T) {
+	type CLI struct {
+		Path string `type:"existingfile" default:"testdata/missing.txt"`
+	}
+	var cli CLI
+	r, err := kong.JSON(strings.NewReader(`{"path": "testdata/file.txt"}`))
+	assert.NoError(t, err)
+
+	p := mustNew(t, &cli, kong.Resolvers(r))
+	_, err = p.Parse([]string{})
+	assert.NoError(t, err)
+	assert.Contains(t, cli.Path, filepath.Join("testdata", "file.txt"))
+}

--- a/model.go
+++ b/model.go
@@ -392,7 +392,9 @@ func (v *Value) ApplyDefault() error {
 // or its "default" tag.
 //
 // Does not include resolvers.
-func (v *Value) Reset() error {
+func (v *Value) Reset() error { return v.reset(false) }
+
+func (v *Value) reset(skipDefaults bool) error {
 	v.Target.Set(reflect.Zero(v.Target.Type()))
 	if len(v.Tag.Envs) != 0 {
 		for _, env := range v.Tag.Envs {
@@ -407,7 +409,7 @@ func (v *Value) Reset() error {
 			}
 		}
 	}
-	if v.HasDefault {
+	if v.HasDefault && !skipDefaults {
 		return v.Parse(ScanFromTokens(Token{Type: FlagValueToken, Value: v.Default}), v.Target)
 	}
 	return nil


### PR DESCRIPTION
Fixes #454 — flags with `type:"existingfile"` (also `existingdir`, `filecontent`, `*os.File`) and a `default:` tag fail during `Reset()` even when a config file/resolver provides a valid path, because the default is parsed (and stat'd) before `Resolve()` runs.

## What
In `Kong.Parse`, when `resolvers` are registered or a config `loader` is present, defaults are no longer fully parsed during `Reset()`; the skip is scoped so that:

- `Reset()` / `Value.Reset()` (public API) behave exactly as before — a new private `reset(skipDefaults bool)` carries the flag.
- Envar parsing still happens in `Reset()` as before (unchanged).
- If no resolver/loader provides a value, `ApplyDefaults` (`Value.Reset()`) still parses (and thus still validates) the default — so `TestExistingFileMapperDefaultMissing` still errors as it previously did. No silent invalidation.

## Testing
- Red → green: `TestExistingFileMapperDefaultWithConfigLoader` and `TestExistingFileMapperDefaultWithJSONResolver` failed before (stat `missing.txt` at reset) and pass after.
- Regression: existing `TestExistingFileMapperDefaultMissing*` (default must still be validated when nothing overrides it), full `go test ./...`, `golangci-lint` (repo config), `go vet`, `gofmt` — all clean.

Minimal 4-file change (+41/-5).