### PR TITLE
fix: enforce a required xor group with only one required member

### DIFF
--- a/context.go
+++ b/context.go
@@ -1069,7 +1069,7 @@ func checkMissingFlags(flags []*Flag) error {
 		}
 	}
 	for group, flags := range choiceGroups {
-		if !choiceGroupSet[group] && len(flags) > 1 {
+		if !choiceGroupSet[group] && len(flags) > 0 {
 			missing = append(missing, strings.Join(flags, " or "))
 		}
 	}

--- a/kong_test.go
+++ b/kong_test.go
@@ -1422,6 +1422,27 @@ func TestXorRequired(t *testing.T) {
 	assert.EqualError(t, err, "missing flags: --four, --one or --three, --one or --two")
 }
 
+func TestXorRequiredSingleRequiredMember(t *testing.T) {
+	var cli struct {
+		Hello string `xor:"group" required:""`
+		One   string `xor:"group" and:"pair"`
+		Two   string `and:"pair"`
+	}
+
+	p := mustNew(t, &cli)
+	_, err := p.Parse([]string{})
+	assert.EqualError(t, err, "missing flags: --hello=STRING")
+
+	// any member of the group satisfies it, required or not
+	p = mustNew(t, &cli)
+	_, err = p.Parse([]string{"--one=a", "--two=b"})
+	assert.NoError(t, err)
+
+	p = mustNew(t, &cli)
+	_, err = p.Parse([]string{"--hello=a"})
+	assert.NoError(t, err)
+}
+
 func TestAndRequired(t *testing.T) {
 	var cli struct {
 		One   bool `and:"one,two" required:""`


### PR DESCRIPTION
A required flag in an `xor` group is silently ignored when it is the only required member of that group:

```go
var cli struct {
    Hello string `xor:"group" required:""`
    One   string `xor:"group"`
}
p.Parse([]string{})   // returns nil, --hello never provided
```

`checkMissingFlags` collects the unset required members of each group, then reports the group only `if !xorGroupSet[xor] && len(flags) > 1`. With one required member `len(flags) == 1`, so the requirement is dropped entirely.

`strings.Join` of a one-element slice already yields the correct single-flag message, so the guard just needs to be `> 0`.

Fixes #516

## Note on the issue title

The report frames this as `xor` + `required` + `and` interacting, but `and` is not involved — the same failure reproduces with a plain two-flag xor group where only one member is required. The reporter's case just happened to have that shape.

## Behaviour checked by hand

| case | before | after |
|---|---|---|
| one required member, no args | `nil` | `missing flags: --hello=STRING` |
| the issue's exact struct, no args | `nil` | `missing flags: --hello=STRING` |
| lone required member, no sibling | `nil` | `missing flags: --only=STRING` |
| no member required, no args | `nil` | `nil` |
| group satisfied by a non-required sibling | `nil` | `nil` |
| both members set | `--a and --b can't be used together` | unchanged |
| two required members, no args | `--a=STRING or --b=STRING` | unchanged |

Flags that are not `required` never enter `xorGroup` — they are skipped by the `!flag.Required || flag.Set` continue above — so this cannot start erroring on optional groups.

`go test ./...` passes, including `TestXorRequired`, `TestXorRequiredMany` and `TestAndRequired`. The new test fails without the change.
