### PR TITLE
test: cover a negatable flag switched back on later in argv

### DIFF
--- a/kong_test.go
+++ b/kong_test.go
@@ -449,6 +449,30 @@ func TestNegatableFlag(t *testing.T) {
 			expectedFlag:   true,
 			expectedCustom: true,
 		},
+		{
+			name:           "negated then positive boolean flag",
+			args:           []string{"cmd", "--no-flag", "--flag"},
+			expectedFlag:   true,
+			expectedCustom: true,
+		},
+		{
+			name:           "positive then negated boolean flag",
+			args:           []string{"cmd", "--flag", "--no-flag"},
+			expectedFlag:   false,
+			expectedCustom: true,
+		},
+		{
+			name:           "custom negated then positive boolean flag",
+			args:           []string{"cmd", "--standard", "--custom"},
+			expectedFlag:   true,
+			expectedCustom: true,
+		},
+		{
+			name:           "custom positive then negated boolean flag",
+			args:           []string{"cmd", "--custom", "--standard"},
+			expectedFlag:   true,
+			expectedCustom: false,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
## Status after rebase: this is now a test-only PR

The one-line fix this PR proposed landed on `master` independently, byte-for-byte:

```go
// context.go, current master
flag.Negated = match == neg && flag.Tag.Negatable != ""
```

So the code change is gone from the diff and only the regression test remains. `context.go` on this branch is identical to `master`.

## What the test still adds

`TestNegatableFlag` has rows for a negatable flag given once, positively or negatively, but none for the same flag appearing twice with opposite polarity. That is the case the assignment above is what makes work: `Flag` is shared across the parse, so a `Negated` set by an earlier `--no-x` used to stick and swallow a later `--x`.

Four rows, one per ordering of each negation style (plain bool and custom bool mapper):

```
--no-flag --flag    -> flag=true
--flag --no-flag    -> flag=false
--standard --custom -> custom=true
--custom --standard -> custom=false
```

## Verification

`go test ./...` green on the rebased branch.

Reverting master's assignment back to the old conditional form fails exactly the two rows where the positive flag comes last, as assertion failures:

```
--- FAIL: TestNegatableFlag/negated_then_positive_boolean_flag
    kong_test.go:487: Expected values to be equal:
        -true
        +false
--- FAIL: TestNegatableFlag/custom_negated_then_positive_boolean_flag
    kong_test.go:488: Expected values to be equal:
        -true
        +false
```

The other two rows pass on the old code, which is the point: the old behavior was right by accident in half the cases. Nothing currently guards the other half.

Close it if you would rather not carry the extra rows.

---
AI-assisted: written with Claude Code, reviewed and tested by me before sending.
