### PR TITLE
Add NoRepeatedFlags option to reject flags passed more than once

### DIFF
--- a/context.go
+++ b/context.go
@@ -281,6 +281,11 @@ func (c *Context) Validate() error { //nolint: gocyclo
 	if err := checkXorDuplicatedAndAndMissing(c.Path); err != nil {
 		return err
 	}
+	if c.Kong.noRepeatedFlags {
+		if err := checkRepeatedFlags(c.Path); err != nil {
+			return err
+		}
+	}
 
 	if node.Type == ArgumentNode {
 		value := node.Argument
@@ -1103,6 +1108,28 @@ func checkXorDuplicatedAndAndMissing(paths []*Path) error {
 	}
 	if len(errs) > 0 {
 		return errors.New(strings.Join(errs, ", "))
+	}
+	return nil
+}
+
+// checkRepeatedFlags reports an error if a non-cumulative flag was explicitly
+// provided more than once on the command line. Cumulative flags (slices and
+// maps) and counters are allowed to repeat, as is a value applied by a resolver
+// (eg. an environment variable) that is then overridden on the command line.
+func checkRepeatedFlags(paths []*Path) error {
+	seen := map[string]bool{}
+	for _, path := range paths {
+		flag := path.Flag
+		if flag == nil || path.Resolved {
+			continue
+		}
+		if flag.IsCumulative() || flag.IsCounter() {
+			continue
+		}
+		if seen[flag.Name] {
+			return fmt.Errorf("flag --%s cannot be repeated", flag.Name)
+		}
+		seen[flag.Name] = true
 	}
 	return nil
 }

--- a/kong.go
+++ b/kong.go
@@ -58,6 +58,7 @@ type Kong struct {
 
 	noDefaultHelp   bool
 	allowHyphenated bool
+	noRepeatedFlags bool
 	usageOnError    usageOnError
 	help            HelpPrinter
 	shortHelp       HelpPrinter

--- a/kong_test.go
+++ b/kong_test.go
@@ -2924,3 +2924,76 @@ func TestParseHyphenParameter(t *testing.T) {
 		assert.Equal(t, &shortFlag{Numeric: -10}, actual)
 	})
 }
+
+func TestNoRepeatedFlags(t *testing.T) {
+	t.Run("repeated scalar flag is allowed by default", func(t *testing.T) {
+		var cli struct {
+			Flag string
+		}
+		_, err := mustNew(t, &cli).Parse([]string{"--flag=first", "--flag=second"})
+		assert.NoError(t, err)
+		assert.Equal(t, "second", cli.Flag)
+	})
+
+	t.Run("repeated scalar flag errors when enabled", func(t *testing.T) {
+		var cli struct {
+			Flag string
+		}
+		_, err := mustNew(t, &cli, kong.NoRepeatedFlags()).Parse([]string{"--flag=first", "--flag=second"})
+		assert.EqualError(t, err, "flag --flag cannot be repeated")
+	})
+
+	t.Run("short and long forms of the same flag count as a repetition", func(t *testing.T) {
+		var cli struct {
+			Flag string `short:"f"`
+		}
+		_, err := mustNew(t, &cli, kong.NoRepeatedFlags()).Parse([]string{"-f", "first", "--flag", "second"})
+		assert.EqualError(t, err, "flag --flag cannot be repeated")
+	})
+
+	t.Run("distinct flags are allowed", func(t *testing.T) {
+		var cli struct {
+			One string
+			Two string
+		}
+		_, err := mustNew(t, &cli, kong.NoRepeatedFlags()).Parse([]string{"--one=1", "--two=2"})
+		assert.NoError(t, err)
+	})
+
+	t.Run("slice flags may be repeated", func(t *testing.T) {
+		var cli struct {
+			Flag []string
+		}
+		_, err := mustNew(t, &cli, kong.NoRepeatedFlags()).Parse([]string{"--flag=a", "--flag=b"})
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"a", "b"}, cli.Flag)
+	})
+
+	t.Run("map flags may be repeated", func(t *testing.T) {
+		var cli struct {
+			Flag map[string]int
+		}
+		_, err := mustNew(t, &cli, kong.NoRepeatedFlags()).Parse([]string{"--flag", "a=1", "--flag", "b=2"})
+		assert.NoError(t, err)
+		assert.Equal(t, map[string]int{"a": 1, "b": 2}, cli.Flag)
+	})
+
+	t.Run("counter flags may be repeated", func(t *testing.T) {
+		var cli struct {
+			Verbose int `short:"v" type:"counter"`
+		}
+		_, err := mustNew(t, &cli, kong.NoRepeatedFlags()).Parse([]string{"-v", "-v", "-v"})
+		assert.NoError(t, err)
+		assert.Equal(t, 3, cli.Verbose)
+	})
+
+	t.Run("a resolved value overridden on the command line is not a repetition", func(t *testing.T) {
+		var cli struct {
+			Flag string `env:"KONG_NRF_FLAG"`
+		}
+		t.Setenv("KONG_NRF_FLAG", "from-env")
+		_, err := mustNew(t, &cli, kong.NoRepeatedFlags()).Parse([]string{"--flag=from-cli"})
+		assert.NoError(t, err)
+		assert.Equal(t, "from-cli", cli.Flag)
+	})
+}

--- a/options.go
+++ b/options.go
@@ -118,6 +118,25 @@ func NoDefaultHelp() Option {
 	})
 }
 
+// NoRepeatedFlags makes Kong return an error when a non-cumulative flag is
+// provided more than once on the command line.
+//
+// By default Kong silently overwrites the value of a scalar flag with each
+// subsequent occurrence, so "--file=a --file=b" leaves the flag set to "b".
+// This can hide typos such as passing "-o" and "--output" for the same
+// underlying field. With this option enabled, such repetitions are reported as
+// an error instead.
+//
+// Flags that are intended to be repeated are exempt: slices and maps (which
+// accumulate values) and counters (which count occurrences) may still appear
+// multiple times.
+func NoRepeatedFlags() Option {
+	return OptionFunc(func(k *Kong) error {
+		k.noRepeatedFlags = true
+		return nil
+	})
+}
+
 // PostBuild provides read/write access to kong.Kong after initial construction of the model is complete but before
 // parsing occurs.
 //


### PR DESCRIPTION
This adds an opt-in `NoRepeatedFlags()` option that makes Kong return an error when a non-cumulative flag is passed more than once on the command line, addressing #441.

Today a scalar flag can be given repeatedly and Kong silently keeps the last value, so `program -o /path --output out.ext` quietly writes to `out.ext` with no hint that two forms of the same flag were used. As noted in the issue this is easy to trip over, and you agreed an opt-in behaviour seemed reasonable (it can't be the default without breaking backwards compatibility). This picks that up where #569 left off and addresses the review feedback there — the previous attempt only exempted slices, but maps and counters are legitimately repeatable too.

The check runs during validation over the parsed path and skips anything that is meant to repeat: cumulative flags (slices and maps) via `IsCumulative()` and counters via `IsCounter()`. It also ignores values applied by a resolver (for example an environment variable) that are then overridden on the command line, so an env default plus one explicit CLI value is not treated as a repetition. Short and long forms of the same flag count as the same flag. The default behaviour is unchanged.

Tests cover the default (repeats still allowed), the error case, short+long equivalence, distinct flags, slices, maps, counters, and the resolver-override case. `go test ./...` and `gofmt` are clean.

I went with the name `NoRepeatedFlags` to match the existing `NoDefaultHelp` style, but happy to rename it (or the error message) if you'd prefer something else.
