### PR TITLE
Add last-wins flag groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,10 +591,11 @@ Both can coexist with standard Tag parsing.
 | `enum:"X,Y,..."`     | Set of valid values allowed for this flag. An enum field must be `required` or have a valid `default`.                                                                                                                                                                                                                         |
 | `group:"X"`          | Logical group for a flag or command.                                                                                                                                                                                                                                                                                           |
 | `xor:"X,Y,..."`      | Exclusive OR groups for flags. Only one flag in the group can be used which is restricted within the same command. When combined with `required`, at least one of the `xor` group will be required.                                                                                                                            |
+| `lastwins:"X"`       | Ordered exclusive group for flags. When multiple flags in the group occur on the command line, only the last is applied. When combined with `required`, at least one flag in the group is required.                                                                                                                           |
 | `and:"X,Y,..."`      | AND groups for flags. All flags in the group must be used in the same command. When combined with `required`, all flags in the group will be required.                                                                                                                                                                         |
 | `prefix:"X"`         | Prefix for all sub-flags.                                                                                                                                                                                                                                                                                                      |
 | `envprefix:"X"`      | Envar prefix for all sub-flags.                                                                                                                                                                                                                                                                                                |
-| `xorprefix:"X"`      | Prefix for all sub-flags in XOR/AND groups.                                                                                                                                                                                                                                                                                  |
+| `xorprefix:"X"`      | Prefix for all sub-flags in XOR/AND/last-wins groups.                                                                                                                                                                                                                                                                          |
 | `set:"K=V"`          | Set a variable for expansion by child elements. Multiples can occur.                                                                                                                                                                                                                                                           |
 | `embed:""`           | If present, this field's children will be embedded in the parent. Useful for composition.                                                                                                                                                                                                                                      |
 | `passthrough:"<mode>"`[^1] | If present on a positional argument, it stops flag parsing when encountered, as if `--` was processed before. Useful for external command wrappers, like `exec`. On a command it requires that the command contains only one argument of type `[]string` which is then filled with everything following the command, unparsed. |
@@ -602,6 +603,17 @@ Both can coexist with standard Tag parsing.
 
 [^1]: `<mode>` can be `partial` or `all` (the default). `all` will pass through all arguments including flags. `partial` will validate flags until the first positional argument is encountered, then pass through all remaining
 positional arguments.
+
+Each flag may belong to one `lastwins` group. Flags in the group retain their normal decoding behavior: repeated scalar values use the last value, while slices and maps continue to accumulate. A command-line occurrence, including an explicit false boolean value, takes precedence over defaults, environment variables, and resolvers. If no group member occurs on the command line, at most one member may receive a fallback value because fallback sources do not define an order across different flags.
+
+```go
+var cli struct {
+  Once  bool `lastwins:"poll-exit"`
+  Drain bool `lastwins:"poll-exit"`
+}
+```
+
+With this grammar, `--once --drain` selects `Drain`, while `--drain --once` selects `Once`.
 
 ## Plugins
 

--- a/README.md
+++ b/README.md
@@ -604,7 +604,7 @@ Both can coexist with standard Tag parsing.
 [^1]: `<mode>` can be `partial` or `all` (the default). `all` will pass through all arguments including flags. `partial` will validate flags until the first positional argument is encountered, then pass through all remaining
 positional arguments.
 
-Each flag may belong to one `lastwins` group. Flags in the group retain their normal decoding behavior: repeated scalar values use the last value, while slices and maps continue to accumulate. A command-line occurrence, including an explicit false boolean value, takes precedence over defaults, environment variables, and resolvers. If no group member occurs on the command line, at most one member may receive a fallback value because fallback sources do not define an order across different flags.
+Each flag may belong to one `lastwins` group, and may not also be in an `xor` or `and` group. Flags in the group retain their normal decoding behavior: repeated scalar values use the last value, while slices and maps continue to accumulate. A command-line occurrence, including an explicit false boolean value, takes precedence over defaults, environment variables, and resolvers. Losing flags are reset to their zero value and are skipped by validation and by `BeforeApply`/`AfterApply` hooks; `BeforeReset` and `BeforeResolve` hooks run before the winner is known and still fire for every member. If no group member occurs on the command line, at most one member may receive a fallback value because fallback sources do not define an order across different flags: at most one member may declare a `default` (enforced by `kong.New`), and conflicting environment or resolver values are reported at parse time.
 
 ```go
 var cli struct {

--- a/build.go
+++ b/build.go
@@ -178,6 +178,12 @@ MAIN:
 			}
 		}
 
+		if len(tag.LastWins) != 0 {
+			for i := range tag.LastWins {
+				tag.LastWins[i] = tag.XorPrefix + tag.LastWins[i]
+			}
+		}
+
 		if len(tag.And) != 0 {
 			for i := range tag.And {
 				tag.And[i] = tag.XorPrefix + tag.And[i]
@@ -378,6 +384,7 @@ func buildField(k *Kong, node *Node, v reflect.Value, ft reflect.StructField, fv
 			Envs:        tag.Envs,
 			Group:       buildGroupForKey(k, tag.Group),
 			Xor:         tag.Xor,
+			LastWins:    tag.LastWins,
 			And:         tag.And,
 			Hidden:      tag.Hidden,
 		}

--- a/context.go
+++ b/context.go
@@ -91,6 +91,8 @@ type Context struct {
 	bindings  bindings
 	resolvers []Resolver // Extra context-specific resolvers.
 	scan      *Scanner
+
+	lastWinsInactive map[*Flag]bool
 }
 
 // Trace path of "args" through the grammar tree.
@@ -196,6 +198,9 @@ func (c *Context) Validate() error { //nolint: gocyclo
 			continue
 		}
 		for _, value := range node.Values() {
+			if value.Flag != nil && c.isFlagInactive(value.Flag) {
+				continue
+			}
 			ok := atLeastOneEnvSet(value.Tag.Envs)
 			if value.Enum != "" && (!value.Required || value.HasDefault || (len(value.Tag.Envs) != 0 && ok)) {
 				if err := checkEnum(value, value.Target); err != nil {
@@ -205,6 +210,9 @@ func (c *Context) Validate() error { //nolint: gocyclo
 		}
 	}
 	for _, el := range c.Path {
+		if el.Flag != nil && c.isFlagInactive(el.Flag) {
+			continue
+		}
 		var (
 			value reflect.Value
 			desc  string
@@ -612,7 +620,7 @@ func (c *Context) maybeSelectDefault(flags []*Flag, node *Node) error {
 func (c *Context) Resolve() error {
 	resolvers := c.combineResolvers()
 	if len(resolvers) == 0 {
-		return nil
+		return c.resolveLastWins()
 	}
 
 	inserted := []*Path{}
@@ -654,7 +662,114 @@ func (c *Context) Resolve() error {
 		}
 	}
 	c.Path = append(c.Path, inserted...)
+	return c.resolveLastWins()
+}
+
+// resolveLastWins selects the effective member of each lastwins group. Command-line
+// occurrences are ordered, so the final occurrence wins. Defaults, environment
+// variables, and resolvers do not define an order across different flags and may
+// therefore provide at most one fallback value per group.
+func (c *Context) resolveLastWins() error {
+	c.lastWinsInactive = map[*Flag]bool{}
+	seenNodes := map[*Node]bool{}
+	for _, path := range c.Path {
+		node := path.Node()
+		if node == nil || seenNodes[node] {
+			continue
+		}
+		seenNodes[node] = true
+
+		for group, members := range lastWinsGroups(node.Flags) {
+			memberSet := map[*Flag]bool{}
+			for _, member := range members {
+				memberSet[member] = true
+			}
+
+			winner := lastCommandLineWinner(c.Path, memberSet)
+			if winner == nil {
+				var fallbackNames []string
+				winner, fallbackNames = lastWinsFallback(c.Path, members, memberSet)
+				if len(fallbackNames) > 1 {
+					return &lastWinsError{group: group, flags: fallbackNames}
+				}
+			}
+
+			c.deactivateLastWinsLosers(members, winner)
+		}
+	}
 	return nil
+}
+
+func lastWinsGroups(flags []*Flag) map[string][]*Flag {
+	groups := map[string][]*Flag{}
+	for _, flag := range flags {
+		for _, group := range flag.LastWins {
+			groups[group] = append(groups[group], flag)
+		}
+	}
+	return groups
+}
+
+func lastCommandLineWinner(paths []*Path, members map[*Flag]bool) *Flag {
+	var winner *Flag
+	for _, occurrence := range paths {
+		if occurrence.Flag != nil && !occurrence.Resolved && members[occurrence.Flag] {
+			winner = occurrence.Flag
+		}
+	}
+	return winner
+}
+
+func lastWinsFallback(paths []*Path, members []*Flag, memberSet map[*Flag]bool) (*Flag, []string) {
+	fallbacks := map[*Flag]bool{}
+	for _, occurrence := range paths {
+		if occurrence.Flag != nil && occurrence.Resolved && memberSet[occurrence.Flag] {
+			fallbacks[occurrence.Flag] = true
+		}
+	}
+	for _, member := range members {
+		if member.HasDefault || atLeastOneEnvSet(member.Tag.Envs) {
+			fallbacks[member] = true
+		}
+	}
+
+	var winner *Flag
+	names := []string{}
+	for _, member := range members {
+		if fallbacks[member] {
+			winner = member
+			names = append(names, member.ShortSummary())
+		}
+	}
+	return winner, names
+}
+
+func (c *Context) deactivateLastWinsLosers(members []*Flag, winner *Flag) {
+	if winner == nil {
+		return
+	}
+	for _, member := range members {
+		if member == winner {
+			continue
+		}
+		c.lastWinsInactive[member] = true
+		delete(c.values, member.Value)
+		member.Target.Set(reflect.Zero(member.Target.Type()))
+		member.Set = false
+	}
+}
+
+func (c *Context) isFlagInactive(flag *Flag) bool {
+	return c.lastWinsInactive[flag]
+}
+
+type lastWinsError struct {
+	group string
+	flags []string
+}
+
+func (e *lastWinsError) Error() string {
+	return fmt.Sprintf("lastwins group %q has multiple fallback values: %s", e.group, strings.Join(e.flags, ", "))
 }
 
 // Combine application-level resolvers and context resolvers.
@@ -719,6 +834,9 @@ func (c *Context) Apply() (string, error) {
 		case trace.Command != nil:
 			path = append(path, trace.Command.Name)
 		case trace.Flag != nil:
+			if c.isFlagInactive(trace.Flag) {
+				continue
+			}
 			value = trace.Flag.Value
 		case trace.Positional != nil:
 			path = append(path, "<"+trace.Positional.Name+">")
@@ -911,9 +1029,25 @@ func (c *Context) printHelp(options HelpOptions) error {
 	return c.help(options, c)
 }
 
+type choiceGroup struct {
+	kind string
+	name string
+}
+
+func flagChoiceGroups(flag *Flag) []choiceGroup {
+	groups := make([]choiceGroup, 0, len(flag.Xor)+len(flag.LastWins))
+	for _, name := range flag.Xor {
+		groups = append(groups, choiceGroup{kind: "xor", name: name})
+	}
+	for _, name := range flag.LastWins {
+		groups = append(groups, choiceGroup{kind: "lastwins", name: name})
+	}
+	return groups
+}
+
 func checkMissingFlags(flags []*Flag) error {
-	xorGroupSet := map[string]bool{}
-	xorGroup := map[string][]string{}
+	choiceGroupSet := map[choiceGroup]bool{}
+	choiceGroups := map[choiceGroup][]string{}
 	andGroupSet := map[string]bool{}
 	andGroup := map[string][]string{}
 	missing := []string{}
@@ -922,9 +1056,10 @@ func checkMissingFlags(flags []*Flag) error {
 		for _, and := range flag.And {
 			flag.Required = andGroupRequired[and]
 		}
+		groups := flagChoiceGroups(flag)
 		if flag.Set {
-			for _, xor := range flag.Xor {
-				xorGroupSet[xor] = true
+			for _, group := range groups {
+				choiceGroupSet[group] = true
 			}
 			for _, and := range flag.And {
 				andGroupSet[and] = true
@@ -933,12 +1068,12 @@ func checkMissingFlags(flags []*Flag) error {
 		if !flag.Required || flag.Set {
 			continue
 		}
-		if len(flag.Xor) > 0 || len(flag.And) > 0 {
-			for _, xor := range flag.Xor {
-				if xorGroupSet[xor] {
+		if len(groups) > 0 || len(flag.And) > 0 {
+			for _, group := range groups {
+				if choiceGroupSet[group] {
 					continue
 				}
-				xorGroup[xor] = append(xorGroup[xor], flag.Summary())
+				choiceGroups[group] = append(choiceGroups[group], flag.Summary())
 			}
 			for _, and := range flag.And {
 				andGroup[and] = append(andGroup[and], flag.Summary())
@@ -947,8 +1082,8 @@ func checkMissingFlags(flags []*Flag) error {
 			missing = append(missing, flag.Summary())
 		}
 	}
-	for xor, flags := range xorGroup {
-		if !xorGroupSet[xor] && len(flags) > 1 {
+	for group, flags := range choiceGroups {
+		if !choiceGroupSet[group] && len(flags) > 1 {
 			missing = append(missing, strings.Join(flags, " or "))
 		}
 	}

--- a/kong.go
+++ b/kong.go
@@ -174,7 +174,7 @@ func New(grammar any, options ...Option) (*Kong, error) {
 	if err = checkOverlappingXorAnd(k); err != nil {
 		return nil, err
 	}
-	if err = checkOverlappingLastWins(k); err != nil {
+	if err = checkLastWinsGroups(k); err != nil {
 		return nil, err
 	}
 
@@ -182,60 +182,64 @@ func New(grammar any, options ...Option) (*Kong, error) {
 }
 
 func checkOverlappingXorAnd(k *Kong) error {
-	xorGroups := collectValidationFlagGroups(k.Model.Node.Flags, func(flag *Flag) []string { return flag.Xor })
-	andGroups := collectValidationFlagGroups(k.Model.Node.Flags, func(flag *Flag) []string { return flag.And })
-	return checkGroupOverlap("xor and", xorGroups, andGroups, 1)
+	xorGroups := map[string][]string{}
+	andGroups := map[string][]string{}
+	for _, flag := range k.Model.Node.Flags {
+		for _, xor := range flag.Xor {
+			xorGroups[xor] = append(xorGroups[xor], flag.Name)
+		}
+		for _, and := range flag.And {
+			andGroups[and] = append(andGroups[and], flag.Name)
+		}
+	}
+	for xor, xorSet := range xorGroups {
+		for and, andSet := range andGroups {
+			overlappingEntries := []string{}
+			for _, xorTag := range xorSet {
+				for _, andTag := range andSet {
+					if xorTag == andTag {
+						overlappingEntries = append(overlappingEntries, xorTag)
+					}
+				}
+			}
+			if len(overlappingEntries) > 1 {
+				return fmt.Errorf("invalid xor and combination, %s and %s overlap with more than one: %s", xor, and, overlappingEntries)
+			}
+		}
+	}
+	return nil
 }
 
-func checkOverlappingLastWins(k *Kong) error {
+// checkLastWinsGroups validates lastwins groups at construction time: a flag may
+// not also be in an xor or and group, and at most one member of a lastwins group
+// may declare a default value, since defaults have no cross-flag ordering.
+func checkLastWinsGroups(k *Kong) error {
 	return Visit(k.Model.Node, func(visitable Visitable, next Next) error {
 		node, ok := visitable.(*Node)
 		if !ok {
 			return next(nil)
 		}
-		lastWinsGroups := collectValidationFlagGroups(node.Flags, func(flag *Flag) []string { return flag.LastWins })
-		xorGroups := collectValidationFlagGroups(node.Flags, func(flag *Flag) []string { return flag.Xor })
-		if err := checkGroupOverlap("lastwins and xor", lastWinsGroups, xorGroups, 1); err != nil {
-			return err
+		defaulted := map[string][]string{}
+		for _, flag := range node.Flags {
+			for _, group := range flag.LastWins {
+				if len(flag.Xor) > 0 {
+					return fmt.Errorf("--%s cannot combine lastwins group %q with xor group %q", flag.Name, group, flag.Xor[0])
+				}
+				if len(flag.And) > 0 {
+					return fmt.Errorf("--%s cannot combine lastwins group %q with and group %q", flag.Name, group, flag.And[0])
+				}
+				if flag.HasDefault {
+					defaulted[group] = append(defaulted[group], "--"+flag.Name)
+				}
+			}
 		}
-		andGroups := collectValidationFlagGroups(node.Flags, func(flag *Flag) []string { return flag.And })
-		if err := checkGroupOverlap("lastwins and", lastWinsGroups, andGroups, 0); err != nil {
-			return err
+		for group, flags := range defaulted {
+			if len(flags) > 1 {
+				return fmt.Errorf("lastwins group %q has multiple flags with default values: %s", group, strings.Join(flags, ", "))
+			}
 		}
 		return next(nil)
 	})
-}
-
-func collectValidationFlagGroups(flags []*Flag, groups func(*Flag) []string) map[string][]string {
-	groupFlags := map[string][]string{}
-	for _, flag := range flags {
-		for _, group := range groups(flag) {
-			groupFlags[group] = append(groupFlags[group], flag.Name)
-		}
-	}
-	return groupFlags
-}
-
-func checkGroupOverlap(description string, leftGroups, rightGroups map[string][]string, allowedOverlap int) error {
-	for left, leftFlags := range leftGroups {
-		for right, rightFlags := range rightGroups {
-			overlap := []string{}
-			for _, leftFlag := range leftFlags {
-				for _, rightFlag := range rightFlags {
-					if leftFlag == rightFlag {
-						overlap = append(overlap, leftFlag)
-					}
-				}
-			}
-			if len(overlap) > allowedOverlap {
-				if allowedOverlap == 0 {
-					return fmt.Errorf("invalid %s combination, %s and %s overlap: %s", description, left, right, overlap)
-				}
-				return fmt.Errorf("invalid %s combination, %s and %s overlap with more than one: %s", description, left, right, overlap)
-			}
-		}
-	}
-	return nil
 }
 
 type varStack []Vars
@@ -369,10 +373,6 @@ func (k *Kong) Parse(args []string) (ctx *Context, err error) {
 		return nil, &ParseError{error: err, Context: ctx}
 	}
 	if err = ctx.Resolve(); err != nil {
-		var lastWinsErr *lastWinsError
-		if errors.As(err, &lastWinsErr) {
-			return nil, &ParseError{error: err, Context: ctx, exitCode: exitUsageError}
-		}
 		return nil, &ParseError{error: err, Context: ctx}
 	}
 	if err = k.applyHook(ctx, "BeforeApply"); err != nil {

--- a/kong.go
+++ b/kong.go
@@ -174,33 +174,64 @@ func New(grammar any, options ...Option) (*Kong, error) {
 	if err = checkOverlappingXorAnd(k); err != nil {
 		return nil, err
 	}
+	if err = checkOverlappingLastWins(k); err != nil {
+		return nil, err
+	}
 
 	return k, nil
 }
 
 func checkOverlappingXorAnd(k *Kong) error {
-	xorGroups := map[string][]string{}
-	andGroups := map[string][]string{}
-	for _, flag := range k.Model.Node.Flags {
-		for _, xor := range flag.Xor {
-			xorGroups[xor] = append(xorGroups[xor], flag.Name)
+	xorGroups := collectValidationFlagGroups(k.Model.Node.Flags, func(flag *Flag) []string { return flag.Xor })
+	andGroups := collectValidationFlagGroups(k.Model.Node.Flags, func(flag *Flag) []string { return flag.And })
+	return checkGroupOverlap("xor and", xorGroups, andGroups, 1)
+}
+
+func checkOverlappingLastWins(k *Kong) error {
+	return Visit(k.Model.Node, func(visitable Visitable, next Next) error {
+		node, ok := visitable.(*Node)
+		if !ok {
+			return next(nil)
 		}
-		for _, and := range flag.And {
-			andGroups[and] = append(andGroups[and], flag.Name)
+		lastWinsGroups := collectValidationFlagGroups(node.Flags, func(flag *Flag) []string { return flag.LastWins })
+		xorGroups := collectValidationFlagGroups(node.Flags, func(flag *Flag) []string { return flag.Xor })
+		if err := checkGroupOverlap("lastwins and xor", lastWinsGroups, xorGroups, 1); err != nil {
+			return err
+		}
+		andGroups := collectValidationFlagGroups(node.Flags, func(flag *Flag) []string { return flag.And })
+		if err := checkGroupOverlap("lastwins and", lastWinsGroups, andGroups, 0); err != nil {
+			return err
+		}
+		return next(nil)
+	})
+}
+
+func collectValidationFlagGroups(flags []*Flag, groups func(*Flag) []string) map[string][]string {
+	groupFlags := map[string][]string{}
+	for _, flag := range flags {
+		for _, group := range groups(flag) {
+			groupFlags[group] = append(groupFlags[group], flag.Name)
 		}
 	}
-	for xor, xorSet := range xorGroups {
-		for and, andSet := range andGroups {
-			overlappingEntries := []string{}
-			for _, xorTag := range xorSet {
-				for _, andTag := range andSet {
-					if xorTag == andTag {
-						overlappingEntries = append(overlappingEntries, xorTag)
+	return groupFlags
+}
+
+func checkGroupOverlap(description string, leftGroups, rightGroups map[string][]string, allowedOverlap int) error {
+	for left, leftFlags := range leftGroups {
+		for right, rightFlags := range rightGroups {
+			overlap := []string{}
+			for _, leftFlag := range leftFlags {
+				for _, rightFlag := range rightFlags {
+					if leftFlag == rightFlag {
+						overlap = append(overlap, leftFlag)
 					}
 				}
 			}
-			if len(overlappingEntries) > 1 {
-				return fmt.Errorf("invalid xor and combination, %s and %s overlap with more than one: %s", xor, and, overlappingEntries)
+			if len(overlap) > allowedOverlap {
+				if allowedOverlap == 0 {
+					return fmt.Errorf("invalid %s combination, %s and %s overlap: %s", description, left, right, overlap)
+				}
+				return fmt.Errorf("invalid %s combination, %s and %s overlap with more than one: %s", description, left, right, overlap)
 			}
 		}
 	}
@@ -338,6 +369,10 @@ func (k *Kong) Parse(args []string) (ctx *Context, err error) {
 		return nil, &ParseError{error: err, Context: ctx}
 	}
 	if err = ctx.Resolve(); err != nil {
+		var lastWinsErr *lastWinsError
+		if errors.As(err, &lastWinsErr) {
+			return nil, &ParseError{error: err, Context: ctx, exitCode: exitUsageError}
+		}
 		return nil, &ParseError{error: err, Context: ctx}
 	}
 	if err = k.applyHook(ctx, "BeforeApply"); err != nil {
@@ -357,6 +392,9 @@ func (k *Kong) Parse(args []string) (ctx *Context, err error) {
 
 func (k *Kong) applyHook(ctx *Context, name string) error {
 	for _, trace := range ctx.Path {
+		if trace.Flag != nil && ctx.isFlagInactive(trace.Flag) {
+			continue
+		}
 		var value reflect.Value
 		switch {
 		case trace.App != nil:
@@ -408,6 +446,9 @@ func (k *Kong) applyHookToDefaultFlags(ctx *Context, node *Node, name string) er
 		}
 		binds := k.bindings.clone().add(ctx).add(node.Vars().CloneWith(k.vars))
 		for _, flag := range node.Flags {
+			if ctx.isFlagInactive(flag) {
+				continue
+			}
 			// Flags handled here are the ones that won't show up in ctx.Path:
 			// they got their value from the default tag or an env var, both of
 			// which Reset() applies straight to the target without touching the

--- a/kong_test.go
+++ b/kong_test.go
@@ -1219,11 +1219,32 @@ func TestLastWinsFallbacks(t *testing.T) {
 		assert.Equal(t, "explicit", cli.Two)
 	})
 
-	t.Run("conflicting defaults", func(t *testing.T) {
+	t.Run("conflicting defaults are rejected at construction", func(t *testing.T) {
 		var cli struct {
 			One string `lastwins:"group" default:"one"`
 			Two string `lastwins:"group" default:"two"`
 		}
+		_, err := kong.New(&cli)
+		assert.EqualError(t, err, `lastwins group "group" has multiple flags with default values: --one, --two`)
+	})
+
+	t.Run("conflicting environment fallbacks", func(t *testing.T) {
+		var cli struct {
+			One string `lastwins:"group" env:"KONG_LASTWINS_ONE"`
+			Two string `lastwins:"group" env:"KONG_LASTWINS_TWO"`
+		}
+		t.Setenv("KONG_LASTWINS_ONE", "one")
+		t.Setenv("KONG_LASTWINS_TWO", "two")
+		_, err := mustNew(t, &cli).Parse(nil)
+		assert.EqualError(t, err, `lastwins group "group" has multiple fallback values: --one, --two`)
+	})
+
+	t.Run("default conflicts with environment fallback", func(t *testing.T) {
+		var cli struct {
+			One string `lastwins:"group" default:"one"`
+			Two string `lastwins:"group" env:"KONG_LASTWINS_TWO"`
+		}
+		t.Setenv("KONG_LASTWINS_TWO", "two")
 		_, err := mustNew(t, &cli).Parse(nil)
 		assert.EqualError(t, err, `lastwins group "group" has multiple fallback values: --one, --two`)
 	})
@@ -1319,6 +1340,84 @@ func TestLastWinsIsScopedToCommand(t *testing.T) {
 	assert.True(t, cli.One)
 	assert.False(t, cli.Cmd.Two)
 	assert.True(t, cli.Cmd.Three)
+}
+
+func TestLastWinsNegatable(t *testing.T) {
+	type CLI struct {
+		Once  bool `lastwins:"group" negatable:""`
+		Drain bool `lastwins:"group"`
+	}
+
+	cli := CLI{}
+	_, err := mustNew(t, &cli).Parse([]string{"--drain", "--no-once"})
+	assert.NoError(t, err)
+	assert.False(t, cli.Once) // Once won, with its negated value.
+	assert.False(t, cli.Drain)
+
+	cli = CLI{}
+	_, err = mustNew(t, &cli).Parse([]string{"--no-once", "--drain"})
+	assert.NoError(t, err)
+	assert.False(t, cli.Once)
+	assert.True(t, cli.Drain)
+}
+
+func TestLastWinsLoserSkipsEnumValidation(t *testing.T) {
+	var cli struct {
+		Mode  string `lastwins:"group" enum:"alpha,beta" default:"alpha"`
+		Other string `lastwins:"group"`
+	}
+	// The loser is reset to its zero value, which is not a valid enum; it must
+	// be excluded from enum validation.
+	_, err := mustNew(t, &cli).Parse([]string{"--other=value"})
+	assert.NoError(t, err)
+	assert.Equal(t, "", cli.Mode)
+	assert.Equal(t, "value", cli.Other)
+}
+
+type lastWinsHookContext struct {
+	calls []string
+}
+
+type lastWinsHookFlag bool
+
+func (l *lastWinsHookFlag) BeforeReset(ctx *lastWinsHookContext) error {
+	ctx.calls = append(ctx.calls, "BeforeReset")
+	return nil
+}
+
+func (l *lastWinsHookFlag) BeforeResolve(ctx *lastWinsHookContext) error {
+	ctx.calls = append(ctx.calls, "BeforeResolve")
+	return nil
+}
+
+func (l *lastWinsHookFlag) BeforeApply(ctx *lastWinsHookContext) error {
+	ctx.calls = append(ctx.calls, "BeforeApply")
+	return nil
+}
+
+func (l *lastWinsHookFlag) AfterApply(ctx *lastWinsHookContext) error {
+	ctx.calls = append(ctx.calls, "AfterApply")
+	return nil
+}
+
+func TestLastWinsLoserHooks(t *testing.T) {
+	var cli struct {
+		Once  lastWinsHookFlag `lastwins:"group"`
+		Drain bool             `lastwins:"group"`
+	}
+	hookCtx := &lastWinsHookContext{}
+	_, err := mustNew(t, &cli, kong.Bind(hookCtx)).Parse([]string{"--once", "--drain"})
+	assert.NoError(t, err)
+	// The winner is only known after Resolve, so hooks that run earlier still
+	// fire for losing flags; BeforeApply/AfterApply are skipped.
+	assert.Equal(t, []string{"BeforeReset", "BeforeResolve"}, hookCtx.calls)
+
+	hookCtx.calls = nil
+	cli.Once = false
+	cli.Drain = false
+	_, err = mustNew(t, &cli, kong.Bind(hookCtx)).Parse([]string{"--drain", "--once"})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"BeforeReset", "BeforeResolve", "BeforeApply", "AfterApply"}, hookCtx.calls)
 }
 
 func TestAnd(t *testing.T) {
@@ -1444,7 +1543,17 @@ func TestOverlappingLastWinsGroups(t *testing.T) {
 			Two bool `lastwins:"ordered" xor:"strict"`
 		}
 		_, err := kong.New(&cli)
-		assert.EqualError(t, err, "invalid lastwins and xor combination, ordered and strict overlap with more than one: [one two]")
+		assert.EqualError(t, err, `--one cannot combine lastwins group "ordered" with xor group "strict"`)
+	})
+
+	t.Run("xor with a single shared flag", func(t *testing.T) {
+		var cli struct {
+			One   bool `lastwins:"ordered" xor:"strict"`
+			Two   bool `lastwins:"ordered"`
+			Three bool `xor:"strict"`
+		}
+		_, err := kong.New(&cli)
+		assert.EqualError(t, err, `--one cannot combine lastwins group "ordered" with xor group "strict"`)
 	})
 
 	t.Run("and in child command", func(t *testing.T) {
@@ -1456,7 +1565,7 @@ func TestOverlappingLastWinsGroups(t *testing.T) {
 			} `cmd:""`
 		}
 		_, err := kong.New(&cli)
-		assert.EqualError(t, err, "invalid lastwins and combination, ordered and together overlap: [one]")
+		assert.EqualError(t, err, `--one cannot combine lastwins group "ordered" with and group "together"`)
 	})
 }
 

--- a/kong_test.go
+++ b/kong_test.go
@@ -1153,6 +1153,174 @@ func TestXor(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestLastWins(t *testing.T) {
+	type CLI struct {
+		Once  bool `lastwins:"poll-exit" short:"o" aliases:"single"`
+		Drain bool `lastwins:"poll-exit" short:"d"`
+	}
+	tests := []struct {
+		name  string
+		args  []string
+		once  bool
+		drain bool
+	}{
+		{name: "neither"},
+		{name: "once", args: []string{"--once"}, once: true},
+		{name: "drain", args: []string{"--drain"}, drain: true},
+		{name: "drain last", args: []string{"--once", "--drain"}, drain: true},
+		{name: "once last", args: []string{"--drain", "--once"}, once: true},
+		{name: "short names", args: []string{"-o", "-d"}, drain: true},
+		{name: "alias", args: []string{"--drain", "--single"}, once: true},
+		{name: "explicit false wins", args: []string{"--drain", "--once=false"}},
+		{name: "repeated winner", args: []string{"--once", "--drain", "--once"}, once: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cli := CLI{}
+			_, err := mustNew(t, &cli).Parse(test.args)
+			assert.NoError(t, err)
+			assert.Equal(t, test.once, cli.Once)
+			assert.Equal(t, test.drain, cli.Drain)
+		})
+	}
+}
+
+func TestLastWinsPreservesWinningFlagDecodeSemantics(t *testing.T) {
+	var cli struct {
+		One []string `lastwins:"group"`
+		Two []string `lastwins:"group"`
+	}
+	_, err := mustNew(t, &cli).Parse([]string{"--one=a", "--two=b", "--one=c"})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"a", "c"}, cli.One)
+	assert.Equal(t, []string(nil), cli.Two)
+}
+
+func TestLastWinsFallbacks(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		var cli struct {
+			One string `lastwins:"group" default:"default"`
+			Two string `lastwins:"group"`
+		}
+		_, err := mustNew(t, &cli).Parse(nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "default", cli.One)
+		assert.Equal(t, "", cli.Two)
+	})
+
+	t.Run("command line overrides default", func(t *testing.T) {
+		var cli struct {
+			One string `lastwins:"group" default:"default"`
+			Two string `lastwins:"group"`
+		}
+		_, err := mustNew(t, &cli).Parse([]string{"--two=explicit"})
+		assert.NoError(t, err)
+		assert.Equal(t, "", cli.One)
+		assert.Equal(t, "explicit", cli.Two)
+	})
+
+	t.Run("conflicting defaults", func(t *testing.T) {
+		var cli struct {
+			One string `lastwins:"group" default:"one"`
+			Two string `lastwins:"group" default:"two"`
+		}
+		_, err := mustNew(t, &cli).Parse(nil)
+		assert.EqualError(t, err, `lastwins group "group" has multiple fallback values: --one, --two`)
+	})
+
+	t.Run("resolver", func(t *testing.T) {
+		var cli struct {
+			One string `lastwins:"group"`
+			Two string `lastwins:"group"`
+		}
+		resolver := kong.ResolverFunc(func(_ *kong.Context, _ *kong.Path, flag *kong.Flag) (any, error) {
+			if flag.Name == "one" {
+				return "resolved", nil
+			}
+			return nil, nil
+		})
+		_, err := mustNew(t, &cli, kong.Resolvers(resolver)).Parse(nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "resolved", cli.One)
+		assert.Equal(t, "", cli.Two)
+	})
+
+	t.Run("environment", func(t *testing.T) {
+		var cli struct {
+			One string `lastwins:"group" env:"KONG_LASTWINS_ONE"`
+			Two string `lastwins:"group"`
+		}
+		t.Setenv("KONG_LASTWINS_ONE", "environment")
+		_, err := mustNew(t, &cli).Parse(nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "environment", cli.One)
+		assert.Equal(t, "", cli.Two)
+	})
+
+	t.Run("conflicting resolvers", func(t *testing.T) {
+		var cli struct {
+			One string `lastwins:"group"`
+			Two string `lastwins:"group"`
+		}
+		resolver := kong.ResolverFunc(func(_ *kong.Context, _ *kong.Path, flag *kong.Flag) (any, error) {
+			if flag.Name == "one" || flag.Name == "two" {
+				return flag.Name, nil
+			}
+			return nil, nil
+		})
+		_, err := mustNew(t, &cli, kong.Resolvers(resolver)).Parse(nil)
+		assert.EqualError(t, err, `lastwins group "group" has multiple fallback values: --one, --two`)
+	})
+
+	t.Run("command line overrides conflicting resolvers", func(t *testing.T) {
+		var cli struct {
+			One string `lastwins:"group"`
+			Two string `lastwins:"group"`
+		}
+		resolver := kong.ResolverFunc(func(_ *kong.Context, _ *kong.Path, flag *kong.Flag) (any, error) {
+			if flag.Name == "one" || flag.Name == "two" {
+				return flag.Name, nil
+			}
+			return nil, nil
+		})
+		_, err := mustNew(t, &cli, kong.Resolvers(resolver)).Parse([]string{"--two=explicit"})
+		assert.NoError(t, err)
+		assert.Equal(t, "", cli.One)
+		assert.Equal(t, "explicit", cli.Two)
+	})
+}
+
+func TestLastWinsRequired(t *testing.T) {
+	type CLI struct {
+		One bool `lastwins:"group" required:""`
+		Two bool `lastwins:"group" required:""`
+	}
+	cli := CLI{}
+	_, err := mustNew(t, &cli).Parse(nil)
+	assert.EqualError(t, err, "missing flags: --one or --two")
+
+	cli = CLI{}
+	_, err = mustNew(t, &cli).Parse([]string{"--one", "--two"})
+	assert.NoError(t, err)
+	assert.False(t, cli.One)
+	assert.True(t, cli.Two)
+}
+
+func TestLastWinsIsScopedToCommand(t *testing.T) {
+	var cli struct {
+		One bool `lastwins:"group"`
+		Cmd struct {
+			Two   bool `lastwins:"group"`
+			Three bool `lastwins:"group"`
+		} `cmd:""`
+	}
+	_, err := mustNew(t, &cli).Parse([]string{"--one", "cmd", "--two", "--three"})
+	assert.NoError(t, err)
+	assert.True(t, cli.One)
+	assert.False(t, cli.Cmd.Two)
+	assert.True(t, cli.Cmd.Three)
+}
+
 func TestAnd(t *testing.T) {
 	var cli struct {
 		Hello bool   `and:"another"`
@@ -1267,6 +1435,29 @@ func TestOverLappingXorAnd(t *testing.T) {
 	}
 	_, err := kong.New(&cli)
 	assert.EqualError(t, err, "invalid xor and combination, one and two overlap with more than one: [hello one two]")
+}
+
+func TestOverlappingLastWinsGroups(t *testing.T) {
+	t.Run("xor", func(t *testing.T) {
+		var cli struct {
+			One bool `lastwins:"ordered" xor:"strict"`
+			Two bool `lastwins:"ordered" xor:"strict"`
+		}
+		_, err := kong.New(&cli)
+		assert.EqualError(t, err, "invalid lastwins and xor combination, ordered and strict overlap with more than one: [one two]")
+	})
+
+	t.Run("and in child command", func(t *testing.T) {
+		var cli struct {
+			Cmd struct {
+				One   bool `lastwins:"ordered" and:"together"`
+				Two   bool `lastwins:"ordered"`
+				Three bool `and:"together"`
+			} `cmd:""`
+		}
+		_, err := kong.New(&cli)
+		assert.EqualError(t, err, "invalid lastwins and combination, ordered and together overlap: [one]")
+	})
 }
 
 func TestXorRequired(t *testing.T) {
@@ -2854,6 +3045,29 @@ func TestPrefixXorIssue343(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = kctx.Parse([]string{"--source-password-file=foo", "--source-password=bar"})
 	assert.Error(t, err)
+}
+
+func TestPrefixLastWins(t *testing.T) {
+	type Mode struct {
+		One bool `lastwins:"mode"`
+		Two bool `lastwins:"mode"`
+	}
+	type CLI struct {
+		Source Mode `prefix:"source-" xorprefix:"source-" embed:""`
+		Target Mode `prefix:"target-" xorprefix:"target-" embed:""`
+	}
+
+	cli := CLI{}
+	_, err := mustNew(t, &cli).Parse([]string{"--source-one", "--target-one"})
+	assert.NoError(t, err)
+	assert.True(t, cli.Source.One)
+	assert.True(t, cli.Target.One)
+
+	cli = CLI{}
+	_, err = mustNew(t, &cli).Parse([]string{"--source-one", "--source-two"})
+	assert.NoError(t, err)
+	assert.False(t, cli.Source.One)
+	assert.True(t, cli.Source.Two)
 }
 
 func TestIssue483EmptyRootNodeNoRun(t *testing.T) {

--- a/model.go
+++ b/model.go
@@ -423,6 +423,7 @@ type Flag struct {
 	*Value
 	Group       *Group // Logical grouping when displaying. May also be used by configuration loaders to group options logically.
 	Xor         []string
+	LastWins    []string
 	And         []string
 	PlaceHolder string
 	Envs        []string

--- a/tag.go
+++ b/tag.go
@@ -44,11 +44,12 @@ type Tag struct {
 	Enum            string
 	Group           string
 	Xor             []string
+	LastWins        []string
 	And             []string
 	Vars            Vars
 	Prefix          string // Optional prefix on anonymous structs. All sub-flags will have this prefix.
 	EnvPrefix       string
-	XorPrefix       string // Optional prefix on XOR/AND groups.
+	XorPrefix       string // Optional prefix on XOR/AND/last-wins groups.
 	Embed           bool
 	Aliases         []string
 	Negatable       string
@@ -291,6 +292,18 @@ func hydrateTag(t *Tag, typ reflect.Type) error { //nolint: gocyclo
 	t.Group = t.Get("group")
 	for _, xor := range t.GetAll("xor") {
 		t.Xor = append(t.Xor, strings.FieldsFunc(xor, tagSplitFn)...)
+	}
+	for _, lastWins := range t.GetAll("lastwins") {
+		t.LastWins = append(t.LastWins, strings.FieldsFunc(lastWins, tagSplitFn)...)
+	}
+	if len(t.LastWins) > 0 {
+		group := t.LastWins[0]
+		for _, lastWins := range t.LastWins[1:] {
+			if lastWins != group {
+				return fmt.Errorf("lastwins flags can only belong to one group")
+			}
+		}
+		t.LastWins = t.LastWins[:1]
 	}
 	for _, and := range t.GetAll("and") {
 		t.And = append(t.And, strings.FieldsFunc(and, tagSplitFn)...)

--- a/tag_test.go
+++ b/tag_test.go
@@ -141,6 +141,25 @@ func TestBareAndKongTagsCoexist(t *testing.T) {
 	assert.EqualError(t, err, "--name and --pick can't be used together")
 }
 
+func TestLastWinsKongTag(t *testing.T) {
+	var cli struct {
+		One bool `kong:"lastwins='group'"`
+		Two bool `lastwins:"group"`
+	}
+	_, err := mustNew(t, &cli).Parse([]string{"--one", "--two"})
+	assert.NoError(t, err)
+	assert.False(t, cli.One)
+	assert.True(t, cli.Two)
+}
+
+func TestLastWinsRejectsMultipleGroups(t *testing.T) {
+	var cli struct {
+		Flag bool `lastwins:"one,two"`
+	}
+	_, err := kong.New(&cli)
+	assert.EqualError(t, err, "<anonymous struct>.Flag: lastwins flags can only belong to one group")
+}
+
 func TestManySeps(t *testing.T) {
 	var cli struct {
 		Arg string `arg    optional    default:"hi"`


### PR DESCRIPTION
## Summary

Add a `lastwins:"group"` tag for ordered exclusive flag groups. When multiple members occur on the command line, only the final member is applied:

```go
var cli struct {
    Once  bool `lastwins:"poll-exit"`
    Drain bool `lastwins:"poll-exit"`
}
```

- `--once --drain` selects `Drain`
- `--drain --once` selects `Once`

This is additive: existing `xor` groups retain their strict conflict behavior.

## Prior art

"Last one wins" among mutually exclusive flags is a POSIX-recognized convention: Utility Syntax Guideline 11 permits options "documented as mutually exclusive and … documented to override any incompatible options preceding it". It is ubiquitous in getopt-era tools (`gcc -O0 -O2` — "the last such option is the one that is effective", `ls` sort/format flags) because a loop-and-switch over options gets it for free, and parsers where several flags can write to one destination keep it nearly free (Python argparse via `store_const` with a shared `dest`, click via `flag_value` with a shared name, Perl `Getopt::Long`, Go stdlib `flag.Var`).

Struct-mapped declarative parsers lost that idiom — each flag is welded to its own field — and most only rebuilt "error on conflict" (kong `xor`, picocli exclusive `@ArgGroup`, CLI11 `excludes()`, commander `conflicts()`, yargs `conflicts()`, cobra `MarkFlagsMutuallyExclusive`). Three rebuilt last-wins as a declarative feature:

| Parser | Mechanism | Default |
|---|---|---|
| Rust clap | [`Arg::overrides_with`](https://docs.rs/clap/latest/clap/struct.Arg.html#method.overrides_with) (pairwise; overridden occurrences treated as never supplied) | opt-in; conflict error otherwise |
| Swift ArgumentParser | [`@Flag(exclusivity: .chooseLast)`](https://github.com/apple/swift-argument-parser/blob/main/Sources/ArgumentParser/Parsable%20Properties/Flag.swift) on enum-backed flag groups | opt-in; `.exclusive` (error) otherwise |
| Kotlin clikt | [`option().switch(...)`](https://ajalt.github.io/clikt/options/#feature-switch-flags) maps several flag names to one value; aggregate is `lastOrNull()` | last-wins is the default |

This PR follows the group-scoped design (like Swift's enum groups) rather than clap's pairwise declarations, which need O(n²) edges for groups of three or more flags.

## Semantics

- Command-line ordering is read from `Context.Path`, so short names, aliases, and negatable forms (`--no-flag`) work without special handling.
- An occurrence with an explicit value such as `--once=false` still selects that group member.
- Repeated occurrences of the winning flag retain the mapper's normal behavior: scalars use their final value, while slices/maps continue accumulating.
- Explicit command-line members take precedence over defaults, environment values, and resolvers.
- Losing fields are reset to their zero value and excluded from validation (including `enum` checks) and from `BeforeApply`/`AfterApply` hooks. `BeforeReset` and `BeforeResolve` hooks run before the winner is known, so they still fire for every member. Note this differs from clap, where an overridden flag falls back to its own default; kong instead preserves an "exactly one active member" invariant.
- If no member occurs on the command line, one member may be supplied by a default, environment value, or resolver. Multiple fallback members are rejected because those sources do not define ordering across different flags: at most one member may declare a `default:`, enforced at `kong.New` time since it is statically knowable; conflicting environment/resolver values are reported at parse time.
- `required` makes the group require at least one effective member.
- Groups remain scoped to their command and support `xorprefix` for embedded grammars.
- A flag is limited to one `lastwins` group because winning one ordered group while losing another does not have an unambiguous target value.
- A `lastwins` flag may not also be in an `xor` or `and` group, rejected at `kong.New` time. Allowing even a single shared flag misbehaves: a shared flag that loses its `lastwins` group has `Set` cleared, so a `required` xor group would report it missing despite the user having typed it.

## Open design questions

This is intentionally a draft because I would particularly value feedback on:

1. Should fallback members remain unordered as implemented, or should Kong define cross-member source precedence such as resolver > environment > default? The current behavior can be relaxed later without breaking callers.

## Notes for reviewers

- Pre-existing inconsistency made more visible here: `checkOverlappingXorAnd` only inspects root-node flags, while the new `checkLastWinsGroups` visits all nodes. Unifying them would be a behavior change (it could surface previously-missed xor/and overlaps in subcommands), so it is left for a follow-up.

## Verification

- `go test ./...`
- `go test -race ./...`
- `golangci-lint run`
