### PR TITLE
Fix provider panic on value-typed errors

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -221,6 +221,15 @@ func callFunction(f reflect.Value, bindings bindings) error {
 	return ferr.(error) //nolint:forcetypeassert
 }
 
+func isNil(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
+	}
+}
+
 func callAnyFunction(f reflect.Value, bindings bindings) (out []any, err error) {
 	if f.Kind() != reflect.Func {
 		return nil, fmt.Errorf("expected function, got %s", f.Type())
@@ -245,7 +254,7 @@ func callAnyFunction(f reflect.Value, bindings bindings) (out []any, err error) 
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", pt, err)
 		}
-		if ferrv := reflect.ValueOf(argv[len(argv)-1]); ferrv.IsValid() && ferrv.Type().Implements(callbackReturnSignature) && !ferrv.IsNil() {
+		if ferrv := reflect.ValueOf(argv[len(argv)-1]); ferrv.IsValid() && ferrv.Type().Implements(callbackReturnSignature) && !isNil(ferrv) {
 			return nil, ferrv.Interface().(error) //nolint:forcetypeassert
 		}
 

--- a/options_test.go
+++ b/options_test.go
@@ -201,3 +201,24 @@ func TestCallbackNonPointerError(t *testing.T) {
 	err = callFunction(reflect.ValueOf(method), p.bindings)
 	assert.EqualError(t, err, "ERROR: failed")
 }
+
+type structError struct {
+	msg string
+}
+
+func (e structError) Error() string {
+	return "ERROR: " + e.msg
+}
+
+func TestBindSingletonProviderValueTypedError(t *testing.T) {
+	var cli struct{}
+	app, err := New(&cli, BindSingletonProvider(func() (string, error) {
+		return "", structError{msg: "failed"}
+	}))
+	assert.NoError(t, err)
+
+	ctx, err := app.Parse(nil)
+	assert.NoError(t, err)
+	_, err = ctx.Call(func(string) {})
+	assert.EqualError(t, err, "ERROR: failed")
+}


### PR DESCRIPTION
A provider can return an error implemented by a value type:

```go
type structError struct{ msg string }

func (e structError) Error() string { return e.msg }

app, _ := kong.New(&cli, kong.BindSingletonProvider(func() (string, error) {
	return "", structError{msg: "failed"}
}))
ctx, _ := app.Parse(nil)
_, _ = ctx.Call(func(string) {})
```

Resolving that binding currently panics:

```text
reflect: call of reflect.Value.IsNil on struct Value
```

`callAnyFunction` checks whether the provider's final return value implements `error`, then calls `reflect.Value.IsNil` on its concrete value. `IsNil` is only valid for nilable kinds, so a struct-backed error reaches an invalid reflection operation.

The fix calls `IsNil` only for the kinds where reflect defines it. Other concrete values implementing `error` are surfaced normally, while the existing provider handling of typed-nil errors is preserved.

`TestBindSingletonProviderValueTypedError` covers the provider resolution and `Context.Call` path above. It reproduces the panic when the `callbacks.go` change is reverted and verifies that the provider error is returned after the fix.

Fixes #649
