### PR TITLE
Add HelpOnEmptyArgs option to print help when no arguments are given

### DIFF
--- a/help_test.go
+++ b/help_test.go
@@ -985,3 +985,52 @@ Flags:
 	t.Log(w.String())
 	assert.Equal(t, expected, w.String())
 }
+
+func TestHelpOnEmptyArgs(t *testing.T) {
+	var cli struct {
+		One struct {
+			Flag string `help:"Nested flag."`
+		} `cmd help:"A subcommand."`
+	}
+	w := bytes.NewBuffer(nil)
+	exited := false
+	app := mustNew(t, &cli,
+		kong.Name("test-app"),
+		kong.Writers(w, w),
+		kong.HelpOnEmptyArgs(),
+		kong.Exit(func(int) {
+			exited = true
+			panic(true) // Panic to fake "exit".
+		}),
+	)
+	panicsTrue(t, func() {
+		_, err := app.Parse([]string{})
+		assert.NoError(t, err)
+	})
+	assert.True(t, exited)
+	expected := `Usage: test-app <command>
+
+Flags:
+  -h, --help    Show context-sensitive help.
+
+Commands:
+  one [flags]
+    A subcommand.
+
+Run "test-app <command> --help" for more information on a command.
+`
+	assert.Equal(t, expected, w.String())
+}
+
+func TestHelpOnEmptyArgsDisabledByDefault(t *testing.T) {
+	var cli struct {
+		One struct {
+			Flag string `help:"Nested flag."`
+		} `cmd help:"A subcommand."`
+	}
+	w := bytes.NewBuffer(nil)
+	app := mustNew(t, &cli, kong.Name("test-app"), kong.Writers(w, w))
+	_, err := app.Parse([]string{})
+	assert.Error(t, err)
+	assert.Equal(t, "expected \"one\"", err.Error())
+}

--- a/kong.go
+++ b/kong.go
@@ -57,6 +57,7 @@ type Kong struct {
 	ignoreFields []*regexp.Regexp
 
 	noDefaultHelp   bool
+	helpOnEmptyArgs bool
 	allowHyphenated bool
 	usageOnError    usageOnError
 	help            HelpPrinter
@@ -324,6 +325,15 @@ func (k *Kong) Parse(args []string) (ctx *Context, err error) {
 	ctx, err = Trace(k, args)
 	if err != nil { // Trace is not expected to return an err
 		return nil, &ParseError{error: err, Context: ctx, exitCode: exitUsageError}
+	}
+	if k.helpOnEmptyArgs && len(args) == 0 {
+		options := k.helpOptions
+		options.Summary = false
+		if err = ctx.printHelp(options); err != nil {
+			return nil, &ParseError{error: err, Context: ctx}
+		}
+		k.Exit(0)
+		return ctx, nil
 	}
 	if ctx.Error != nil {
 		return nil, &ParseError{error: ctx.Error, Context: ctx, exitCode: exitUsageError}

--- a/options.go
+++ b/options.go
@@ -118,6 +118,15 @@ func NoDefaultHelp() Option {
 	})
 }
 
+// HelpOnEmptyArgs configures Kong to print help and exit with status 0 when Parse
+// is called with no arguments, rather than reporting a missing command or argument.
+func HelpOnEmptyArgs() Option {
+	return OptionFunc(func(k *Kong) error {
+		k.helpOnEmptyArgs = true
+		return nil
+	})
+}
+
 // PostBuild provides read/write access to kong.Kong after initial construction of the model is complete but before
 // parsing occurs.
 //


### PR DESCRIPTION
Fixes #33.

This adds a `HelpOnEmptyArgs()` option so that running an app with no arguments prints the help and exits 0, instead of erroring out with a missing command. That's the behaviour discussed in the issue (equivalent to passing `--help` when nothing is given). It's off by default so existing apps are unaffected.

I kept the trigger narrow: it only fires when `Parse` is called with zero args, so an invalid or partial command still gets the usual error. Added tests for the option on and off.